### PR TITLE
feat: add Claude.ai conversation extraction

### DIFF
--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -1,14 +1,15 @@
 {
   "manifest_version": 3,
   "name": "Clio",
-  "version": "1.0.0",
-  "description": "Extract full Gemini conversations to JSON with images",
+  "version": "1.1.0",
+  "description": "Extract full Gemini and Claude conversations to JSON with images",
   "permissions": [
     "activeTab",
     "downloads"
   ],
   "host_permissions": [
-    "https://gemini.google.com/*"
+    "https://gemini.google.com/*",
+    "https://claude.ai/*"
   ],
   "action": {
     "default_popup": "src/popup.html",
@@ -25,6 +26,11 @@
     {
       "matches": ["https://gemini.google.com/*"],
       "js": ["src/selectors.js", "src/content.js"],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["https://claude.ai/*"],
+      "js": ["src/selectors-claude.js", "src/content.js"],
       "run_at": "document_idle"
     }
   ],

--- a/extensions/src/content.js
+++ b/extensions/src/content.js
@@ -8,6 +8,18 @@
 /* global SELECTORS, chrome */
 
 // ============================================================================
+// Site Detection
+// ============================================================================
+
+/**
+ * Get the current site identifier from SELECTORS.
+ * @returns {string} - 'gemini', 'claude', or 'unknown'
+ */
+function getSite() {
+  return (typeof SELECTORS !== 'undefined' && SELECTORS.site) || 'unknown';
+}
+
+// ============================================================================
 // Utility Functions
 // ============================================================================
 
@@ -153,35 +165,39 @@ async function expandAllContent() {
     return 0;
   }
 
-  // Find expand buttons ONLY within the conversation container
-  const expandButtons = container.querySelectorAll(SELECTORS.expandButton);
-  for (const button of expandButtons) {
-    // Safety check: skip menu triggers and global UI buttons
-    if (button.matches('[aria-haspopup="true"], [aria-haspopup="menu"], .mat-menu-trigger, .mat-mdc-menu-trigger')) {
-      continue;
-    }
-    try {
-      button.click();
-      expandedCount++;
-      await sleep(300);
-    } catch (e) {
-      // Silently ignore expansion failures
+  // Find expand buttons ONLY within the conversation container (Gemini only)
+  if (SELECTORS.expandButton) {
+    const expandButtons = container.querySelectorAll(SELECTORS.expandButton);
+    for (const button of expandButtons) {
+      // Safety check: skip menu triggers and global UI buttons
+      if (button.matches('[aria-haspopup="true"], [aria-haspopup="menu"], .mat-menu-trigger, .mat-mdc-menu-trigger')) {
+        continue;
+      }
+      try {
+        button.click();
+        expandedCount++;
+        await sleep(300);
+      } catch (e) {
+        // Silently ignore expansion failures
+      }
     }
   }
 
   // Find thinking toggles ONLY within the conversation container
-  const thinkingToggles = container.querySelectorAll(SELECTORS.thinkingToggle);
-  for (const toggle of thinkingToggles) {
-    // Safety check: skip if it's a menu trigger
-    if (toggle.matches('[aria-haspopup="true"], [aria-haspopup="menu"], .mat-menu-trigger, .mat-mdc-menu-trigger')) {
-      continue;
-    }
-    try {
-      toggle.click();
-      expandedCount++;
-      await sleep(300);
-    } catch (e) {
-      // Silently ignore expansion failures
+  if (SELECTORS.thinkingToggle) {
+    const thinkingToggles = container.querySelectorAll(SELECTORS.thinkingToggle);
+    for (const toggle of thinkingToggles) {
+      // Safety check: skip if it's a menu trigger
+      if (toggle.matches('[aria-haspopup="true"], [aria-haspopup="menu"], .mat-menu-trigger, .mat-mdc-menu-trigger')) {
+        continue;
+      }
+      try {
+        toggle.click();
+        expandedCount++;
+        await sleep(300);
+      } catch (e) {
+        // Silently ignore expansion failures
+      }
     }
   }
 
@@ -239,7 +255,13 @@ function resetScrollConfig() {
  * @returns {number} - Number of message elements
  */
 function countMessages() {
-  // Count ONLY primary Gemini elements (user-query, model-response)
+  const site = getSite();
+  if (site === 'claude') {
+    const userMsgs = document.querySelectorAll('[data-testid="user-message"]');
+    const assistantMsgs = document.querySelectorAll('[data-testid="action-bar-copy"]');
+    return userMsgs.length + assistantMsgs.length;
+  }
+  // Gemini: Count ONLY primary elements (user-query, model-response)
   // Don't use composite SELECTORS which include fallbacks that may be nested
   // This prevents double-counting when .user-query-container is inside user-query
   const userMsgs = document.querySelectorAll('user-query, [data-message-author-role="user"]');
@@ -480,12 +502,21 @@ async function scrollToLoadAllMessages(onProgress) {
  * @returns {string}
  */
 function extractTitle() {
-  const titleEl = document.querySelector(SELECTORS.sessionTitle);
-  if (titleEl) {
-    return titleEl.textContent.trim();
+  if (SELECTORS.sessionTitle) {
+    const titleEl = document.querySelector(SELECTORS.sessionTitle);
+    if (titleEl) {
+      return titleEl.textContent.trim();
+    }
   }
-  // Fallback: use document title
-  return document.title.replace(' - Gemini', '').trim() || 'Untitled Conversation';
+  // Fallback: use document title, stripping site suffix
+  const site = getSite();
+  let title = document.title;
+  if (site === 'claude') {
+    title = title.replace(/ - Claude$/, '');
+  } else {
+    title = title.replace(/ - Gemini$/, '');
+  }
+  return title.trim() || 'Untitled Conversation';
 }
 
 /**
@@ -493,6 +524,13 @@ function extractTitle() {
  * @returns {string}
  */
 function extractConversationId() {
+  const site = getSite();
+  if (site === 'claude') {
+    // Claude URL: /chat/{uuid}
+    const match = window.location.pathname.match(/\/chat\/([a-f0-9-]+)/i);
+    return match ? match[1] : 'unknown';
+  }
+  // Gemini URL: /app/{hex}
   const match = window.location.pathname.match(/\/app\/([a-f0-9]+)/i);
   return match ? match[1] : 'unknown';
 }
@@ -611,12 +649,107 @@ function extractAssistantTurn(element, index) {
 }
 
 /**
- * Find and extract all conversation turns in DOM order.
- * Handles Gemini's DOM structure where each .conversation-container
- * contains both user-query and model-response elements.
+ * Extract a single Claude assistant turn.
+ * Claude uses .row-start-1 for thinking and .row-start-2 for response content.
+ * Tool use is indicated by buttons with group/row class inside .row-start-1.
+ * @param {Element} element - DOM element containing assistant message (the action-bar-copy ancestor)
+ * @param {number} index - Turn index
+ * @returns {Object} - Turn object
+ */
+function extractAssistantTurnClaude(element, index) {
+  const images = findImages(element, index);
+
+  // Extract thinking from .row-start-1
+  let thinking = null;
+  const thinkingEl = element.querySelector(SELECTORS.thinkingContent);
+  if (thinkingEl) {
+    thinking = extractTextContent(thinkingEl);
+  }
+
+  // Extract tool use labels from buttons inside thinking row
+  let toolUse = null;
+  if (SELECTORS.toolUseButton) {
+    const toolButtons = element.querySelectorAll(SELECTORS.toolUseButton);
+    if (toolButtons.length > 0) {
+      toolUse = Array.from(toolButtons).map(btn => btn.textContent.trim());
+    }
+  }
+
+  // Extract response from .row-start-2 (preferred) or fall back to removing thinking
+  let content = '';
+  const responseEl = element.querySelector(SELECTORS.responseContent);
+  if (responseEl) {
+    content = extractTextContent(responseEl);
+  } else {
+    // Fallback: clone and remove thinking
+    const contentClone = element.cloneNode(true);
+    const thinkingClone = contentClone.querySelector(SELECTORS.thinkingContent);
+    if (thinkingClone) {
+      thinkingClone.remove();
+    }
+    content = extractTextContent(contentClone);
+  }
+
+  return {
+    index,
+    role: 'assistant',
+    content,
+    thinking,
+    toolUse,
+    attachments: images.map(img => ({
+      type: 'image',
+      filename: null,
+      originalSrc: img.src
+    }))
+  };
+}
+
+/**
+ * Extract turns from a Claude conversation.
+ * Claude uses a flat container with data-testid attributes to identify messages.
  * @returns {Promise<Array>} - Array of turn objects
  */
-async function extractTurns() {
+async function extractTurnsClaude() {
+  const turns = [];
+  let turnIndex = 0;
+
+  // Find all user and assistant messages and sort by DOM position
+  const userMsgs = Array.from(document.querySelectorAll(SELECTORS.userMessage));
+  const assistantMsgs = Array.from(document.querySelectorAll(SELECTORS.assistantMessage));
+
+  const allMsgs = [...userMsgs, ...assistantMsgs].sort((a, b) => {
+    const position = a.compareDocumentPosition(b);
+    return position & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1;
+  });
+
+  for (let i = 0; i < allMsgs.length; i++) {
+    const element = allMsgs[i];
+    const isUser = element.matches(SELECTORS.userMessage);
+
+    if (isUser) {
+      turns.push(extractUserTurn(element, turnIndex++));
+    } else {
+      // For Claude assistant messages, find the closest parent that contains
+      // both thinking and response content
+      const turnContainer = element.closest('[class*="grid"]') || element.parentElement || element;
+      turns.push(extractAssistantTurnClaude(turnContainer, turnIndex++));
+    }
+
+    if (i > 0 && i % 20 === 0) {
+      showProgress(`Extracting turn ${i}/${allMsgs.length}...`);
+      await sleep(0);
+    }
+  }
+
+  return turns;
+}
+
+/**
+ * Extract turns from a Gemini conversation.
+ * Gemini uses .conversation-container elements with user-query and model-response inside.
+ * @returns {Promise<Array>} - Array of turn objects
+ */
+async function extractTurnsGemini() {
   const turns = [];
   let turnIndex = 0;
 
@@ -625,21 +758,17 @@ async function extractTurns() {
   const containers = document.querySelectorAll('.conversation-container');
 
   if (containers.length > 0) {
-
     for (const container of containers) {
-      // Extract user message from within this container
       const userEl = container.querySelector('user-query, [data-message-author-role="user"]');
       if (userEl) {
         turns.push(extractUserTurn(userEl, turnIndex++));
       }
 
-      // Extract assistant message from within this container
       const assistantEl = container.querySelector('model-response, [data-message-author-role="model"]');
       if (assistantEl) {
         turns.push(extractAssistantTurn(assistantEl, turnIndex++));
       }
 
-      // Progress update
       if (turnIndex % 20 === 0) {
         showProgress(`Extracting turn ${turnIndex}...`);
         await sleep(0);
@@ -650,11 +779,9 @@ async function extractTurns() {
   }
 
   // Strategy 2: Fallback - find user and assistant messages directly
-  // and sort them by DOM position
   const userMsgs = Array.from(document.querySelectorAll(SELECTORS.userMessage));
   const assistantMsgs = Array.from(document.querySelectorAll(SELECTORS.assistantMessage));
 
-  // Combine and sort by DOM position
   const allMsgs = [...userMsgs, ...assistantMsgs].sort((a, b) => {
     const position = a.compareDocumentPosition(b);
     return position & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1;
@@ -664,8 +791,6 @@ async function extractTurns() {
 
   for (let i = 0; i < allMsgs.length; i++) {
     const element = allMsgs[i];
-
-    // Determine role
     const isUser = element.matches('user-query') ||
                    element.matches(SELECTORS.userMessage) ||
                    element.getAttribute('data-message-author-role') === 'user';
@@ -676,7 +801,6 @@ async function extractTurns() {
       turns.push(extractAssistantTurn(element, turnIndex++));
     }
 
-    // Yield to event loop every BATCH_SIZE messages
     if (i > 0 && i % BATCH_SIZE === 0) {
       showProgress(`Extracting turn ${i}/${allMsgs.length}...`);
       await sleep(0);
@@ -684,6 +808,19 @@ async function extractTurns() {
   }
 
   return turns;
+}
+
+/**
+ * Find and extract all conversation turns in DOM order.
+ * Dispatches to site-specific extraction based on SELECTORS.site.
+ * @returns {Promise<Array>} - Array of turn objects
+ */
+async function extractTurns() {
+  const site = getSite();
+  if (site === 'claude') {
+    return extractTurnsClaude();
+  }
+  return extractTurnsGemini();
 }
 
 // ============================================================================
@@ -856,10 +993,12 @@ async function extractImages(turns) {
 async function extractConversation() {
   try {
     // Phase 0: Pre-flight checks
+    const siteName = getSite() === 'claude' ? 'Claude' : 'Gemini';
+
     if (isStreaming()) {
       return {
         success: false,
-        error: 'Gemini is currently generating a response. Please wait for completion before extracting.'
+        error: `${siteName} is currently generating a response. Please wait for completion before extracting.`
       };
     }
 
@@ -867,7 +1006,7 @@ async function extractConversation() {
     if (!validation.valid) {
       return {
         success: false,
-        error: `Gemini UI may have changed. Missing selectors: ${validation.missing.join(', ')}. Please report this issue.`
+        error: `${siteName} UI may have changed. Missing selectors: ${validation.missing.join(', ')}. Please report this issue.`
       };
     }
 
@@ -979,13 +1118,17 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 // Export for testing
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
+    getSite,
     sanitizeFilename,
     extractTitle,
     extractConversationId,
     extractTextContent,
     extractUserTurn,
     extractAssistantTurn,
+    extractAssistantTurnClaude,
     extractTurns,
+    extractTurnsClaude,
+    extractTurnsGemini,
     validateSelectors,
     isStreaming,
     expandAllContent,

--- a/extensions/src/popup.js
+++ b/extensions/src/popup.js
@@ -108,6 +108,30 @@ function setButtonState(enabled, text = 'Extract Conversation') {
 }
 
 // ============================================================================
+// Site Detection Helpers
+// ============================================================================
+
+/**
+ * Check if a URL is a supported conversation site.
+ * @param {string} url
+ * @returns {boolean}
+ */
+function isSupportedSite(url) {
+  if (!url) return false;
+  return url.includes('gemini.google.com') || url.includes('claude.ai');
+}
+
+/**
+ * Get filename prefix based on site URL.
+ * @param {string} url
+ * @returns {string}
+ */
+function getSitePrefix(url) {
+  if (url && url.includes('claude.ai')) return 'claude';
+  return 'gemini';
+}
+
+// ============================================================================
 // Filename Sanitization
 // ============================================================================
 
@@ -222,8 +246,8 @@ async function handleExtract() {
     // Get active tab
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
 
-    if (!tab || !tab.url || !tab.url.includes('gemini.google.com')) {
-      setStatus('Please open a Gemini conversation first.', 'error');
+    if (!tab || !tab.url || !isSupportedSite(tab.url)) {
+      setStatus('Please open a Gemini or Claude conversation first.', 'error');
       setButtonState(true);
       hideProgress();
       return;
@@ -274,7 +298,8 @@ async function handleExtract() {
     // Generate filename
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-').substring(0, 19);
     const title = sanitizeFilename(data.metadata.title);
-    const filename = `gemini-${data.metadata.conversationId}-${title}-${timestamp}.zip`;
+    const sitePrefix = getSitePrefix(tab.url);
+    const filename = `${sitePrefix}-${data.metadata.conversationId}-${title}-${timestamp}.zip`;
 
     // Download
     showProgress('Starting download...');
@@ -312,8 +337,8 @@ if (extractBtn) {
 
   // Check if we're on a Gemini page on load
   chrome.tabs.query({ active: true, currentWindow: true }, ([tab]) => {
-    if (!tab || !tab.url || !tab.url.includes('gemini.google.com')) {
-      setStatus('Open a Gemini conversation to extract.', 'warning');
+    if (!tab || !tab.url || !isSupportedSite(tab.url)) {
+      setStatus('Open a Gemini or Claude conversation to extract.', 'warning');
       setButtonState(false);
     }
   });
@@ -325,6 +350,8 @@ if (extractBtn) {
 
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
+    isSupportedSite,
+    getSitePrefix,
     sanitizeFilename,
     estimateExportSize,
     formatBytes,

--- a/extensions/src/selectors-claude.js
+++ b/extensions/src/selectors-claude.js
@@ -1,0 +1,61 @@
+/**
+ * Centralized DOM selectors for Claude.ai UI elements.
+ * Isolated here for easy maintenance when Claude updates their UI.
+ *
+ * VERIFIED: 2026-02-27 from real Claude DOM snapshot via Playwright
+ * Source: data/claude-b5b2d739_Engineering-first-AI-solution-for-ATT_2026-02-27.json
+ */
+
+const SELECTORS = {
+  site: 'claude',
+
+  // Conversation container — the main content column
+  conversationContainer: '[class*="flex-1"][class*="flex-col"]',
+
+  // Session title — Claude uses document.title
+  sessionTitle: null, // Claude has no in-page title element; use document.title
+
+  // Scroll container
+  scrollContainer: '[class*="flex-1"][class*="overflow-y-auto"], [data-scroll-container]',
+
+  // Message elements
+  userMessage: '[data-testid="user-message"]',
+  assistantMessage: '[data-testid="action-bar-copy"]',
+
+  // All messages (union of user + assistant)
+  allMessages: '[data-testid="user-message"], [data-testid="action-bar-copy"]',
+
+  // Expandable content — thinking toggles in Claude
+  expandButton: null, // Claude doesn't use generic expand buttons
+  thinkingToggle: '.row-start-1 button[aria-expanded="false"]',
+
+  // Thinking and response content within assistant turns
+  thinkingContent: '.row-start-1',
+  responseContent: '.row-start-2',
+
+  // Tool use — buttons with group/row class inside thinking row
+  toolUseButton: '.row-start-1 button.group\\/row',
+
+  // Code blocks
+  codeBlock: 'pre code, .code-block code',
+  codeLanguage: '[data-language], .language-label',
+
+  // Images
+  image: 'img',
+
+  // Streaming indicator
+  streamingIndicator: 'button[aria-label*="Stop"], [data-streaming="true"]',
+
+  // Loading indicator
+  loadingIndicator: '[role="progressbar"], [aria-busy="true"], .loading-spinner'
+};
+
+// For use in content script (non-module context)
+if (typeof window !== 'undefined') {
+  window.SELECTORS = SELECTORS;
+}
+
+// For use in tests (module context)
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { SELECTORS };
+}

--- a/extensions/src/selectors.js
+++ b/extensions/src/selectors.js
@@ -9,6 +9,8 @@
  */
 
 const SELECTORS = {
+  site: 'gemini',
+
   // Conversation structure
   // VERIFIED: <div class="conversation-container message-actions-hover-boundary" id="...">
   // FIXED: Removed 'main' - too broad, causes clicking of global UI elements

--- a/tests/content-claude.test.js
+++ b/tests/content-claude.test.js
@@ -1,0 +1,334 @@
+/**
+ * Unit tests for Claude-specific extraction in content.js.
+ *
+ * NOTE: innerHTML usage here is for test fixtures only (jsdom, not browser).
+ * No untrusted content is involved — all HTML is static test data.
+ */
+
+const {
+  getSite,
+  extractTitle,
+  extractConversationId,
+  extractTextContent,
+  extractUserTurn,
+  extractAssistantTurnClaude,
+  extractTurnsClaude,
+  extractTurns,
+  validateSelectors,
+  countMessages
+} = require('../extensions/src/content.js');
+
+// Load Claude selectors for these tests
+const { SELECTORS: CLAUDE_SELECTORS } = require('../extensions/src/selectors-claude.js');
+
+// Save original SELECTORS so we can restore after each test
+const { SELECTORS: GEMINI_SELECTORS } = require('../extensions/src/selectors.js');
+
+function useClaude() {
+  global.SELECTORS = CLAUDE_SELECTORS;
+  if (typeof window !== 'undefined') window.SELECTORS = CLAUDE_SELECTORS;
+}
+
+function useGemini() {
+  global.SELECTORS = GEMINI_SELECTORS;
+  if (typeof window !== 'undefined') window.SELECTORS = GEMINI_SELECTORS;
+}
+
+beforeEach(() => {
+  useClaude();
+  document.body.innerHTML = '';
+});
+
+afterEach(() => {
+  // Restore Gemini selectors as default (other test files expect this)
+  useGemini();
+});
+
+describe('getSite (Claude)', () => {
+  test('returns claude when Claude selectors loaded', () => {
+    expect(getSite()).toBe('claude');
+  });
+
+  test('returns gemini when Gemini selectors loaded', () => {
+    useGemini();
+    expect(getSite()).toBe('gemini');
+  });
+});
+
+describe('extractTitle (Claude)', () => {
+  test('strips " - Claude" suffix from document.title', () => {
+    document.title = 'Engineering-first AI solution - Claude';
+    expect(extractTitle()).toBe('Engineering-first AI solution');
+  });
+
+  test('returns document title as-is when no suffix', () => {
+    document.title = 'My Conversation';
+    expect(extractTitle()).toBe('My Conversation');
+  });
+
+  test('returns Untitled Conversation for empty title', () => {
+    document.title = '';
+    expect(extractTitle()).toBe('Untitled Conversation');
+  });
+});
+
+describe('extractConversationId (Claude)', () => {
+  const originalLocation = window.location;
+
+  afterEach(() => {
+    delete window.location;
+    window.location = originalLocation;
+  });
+
+  test('extracts UUID from Claude URL', () => {
+    delete window.location;
+    window.location = { pathname: '/chat/b5b2d739-81b0-4ee7-aa1a-3209c66c25d0' };
+    expect(extractConversationId()).toBe('b5b2d739-81b0-4ee7-aa1a-3209c66c25d0');
+  });
+
+  test('returns unknown for non-matching URL', () => {
+    delete window.location;
+    window.location = { pathname: '/settings' };
+    expect(extractConversationId()).toBe('unknown');
+  });
+});
+
+describe('countMessages (Claude)', () => {
+  test('counts user and assistant messages', () => {
+    document.body.innerHTML = [
+      '<div data-testid="user-message">Hello</div>',
+      '<div data-testid="action-bar-copy"></div>',
+      '<div data-testid="user-message">Follow up</div>',
+      '<div data-testid="action-bar-copy"></div>'
+    ].join('');
+    expect(countMessages()).toBe(4);
+  });
+
+  test('returns 0 when no messages', () => {
+    document.body.innerHTML = '<div>No conversation here</div>';
+    expect(countMessages()).toBe(0);
+  });
+});
+
+describe('extractAssistantTurnClaude', () => {
+  test('extracts thinking from .row-start-1', () => {
+    const div = document.createElement('div');
+    const thinking = document.createElement('div');
+    thinking.className = 'row-start-1';
+    thinking.textContent = "Analyzing the user's request carefully.";
+    const response = document.createElement('div');
+    response.className = 'row-start-2';
+    response.textContent = 'Here is my response.';
+    div.appendChild(thinking);
+    div.appendChild(response);
+
+    const turn = extractAssistantTurnClaude(div, 0);
+
+    expect(turn.role).toBe('assistant');
+    expect(turn.thinking).toBe("Analyzing the user's request carefully.");
+    expect(turn.content).toBe('Here is my response.');
+  });
+
+  test('extracts response without thinking', () => {
+    const div = document.createElement('div');
+    const response = document.createElement('div');
+    response.className = 'row-start-2';
+    response.textContent = 'Simple response without thinking.';
+    div.appendChild(response);
+
+    const turn = extractAssistantTurnClaude(div, 1);
+
+    expect(turn.thinking).toBeNull();
+    expect(turn.content).toBe('Simple response without thinking.');
+  });
+
+  test('extracts tool use labels', () => {
+    const div = document.createElement('div');
+    const thinking = document.createElement('div');
+    thinking.className = 'row-start-1';
+    const p = document.createElement('p');
+    p.textContent = 'Let me check the time.';
+    thinking.appendChild(p);
+    const btn = document.createElement('button');
+    btn.className = 'group/row';
+    btn.textContent = 'Get current time';
+    thinking.appendChild(btn);
+    div.appendChild(thinking);
+    const response = document.createElement('div');
+    response.className = 'row-start-2';
+    response.textContent = 'The current time is 3:00 PM.';
+    div.appendChild(response);
+
+    const turn = extractAssistantTurnClaude(div, 0);
+
+    expect(turn.toolUse).toEqual(['Get current time']);
+  });
+
+  test('preserves code blocks in response', () => {
+    const div = document.createElement('div');
+    const response = document.createElement('div');
+    response.className = 'row-start-2';
+    const text = document.createTextNode("Here's the code:");
+    response.appendChild(text);
+    const pre = document.createElement('pre');
+    const code = document.createElement('code');
+    code.setAttribute('data-language', 'python');
+    code.textContent = 'print("hello")';
+    pre.appendChild(code);
+    response.appendChild(pre);
+    div.appendChild(response);
+
+    const turn = extractAssistantTurnClaude(div, 0);
+
+    expect(turn.content).toContain('```python');
+    expect(turn.content).toContain('print("hello")');
+  });
+
+  test('extracts images from assistant turn', () => {
+    const div = document.createElement('div');
+    const response = document.createElement('div');
+    response.className = 'row-start-2';
+    const img = document.createElement('img');
+    img.src = 'data:image/png;base64,abc123';
+    response.appendChild(img);
+    div.appendChild(response);
+
+    const turn = extractAssistantTurnClaude(div, 0);
+
+    expect(turn.attachments).toHaveLength(1);
+    expect(turn.attachments[0].type).toBe('image');
+  });
+});
+
+describe('extractTurnsClaude', () => {
+  test('extracts turns from Claude DOM in order', async () => {
+    // Build DOM programmatically
+    const user1 = document.createElement('div');
+    user1.setAttribute('data-testid', 'user-message');
+    user1.textContent = 'Hello Claude';
+    document.body.appendChild(user1);
+
+    const grid1 = document.createElement('div');
+    grid1.className = 'grid-container';
+    const copy1 = document.createElement('div');
+    copy1.setAttribute('data-testid', 'action-bar-copy');
+    grid1.appendChild(copy1);
+    const resp1 = document.createElement('div');
+    resp1.className = 'row-start-2';
+    resp1.textContent = 'Hi! How can I help?';
+    grid1.appendChild(resp1);
+    document.body.appendChild(grid1);
+
+    const user2 = document.createElement('div');
+    user2.setAttribute('data-testid', 'user-message');
+    user2.textContent = 'What is 2+2?';
+    document.body.appendChild(user2);
+
+    const grid2 = document.createElement('div');
+    grid2.className = 'grid-container';
+    const copy2 = document.createElement('div');
+    copy2.setAttribute('data-testid', 'action-bar-copy');
+    grid2.appendChild(copy2);
+    const think2 = document.createElement('div');
+    think2.className = 'row-start-1';
+    think2.textContent = 'Simple math calculation.';
+    grid2.appendChild(think2);
+    const resp2 = document.createElement('div');
+    resp2.className = 'row-start-2';
+    resp2.textContent = '2+2 equals 4.';
+    grid2.appendChild(resp2);
+    document.body.appendChild(grid2);
+
+    const turns = await extractTurnsClaude();
+
+    expect(turns).toHaveLength(4);
+    expect(turns[0].role).toBe('user');
+    expect(turns[0].content).toBe('Hello Claude');
+    expect(turns[1].role).toBe('assistant');
+    expect(turns[2].role).toBe('user');
+    expect(turns[2].content).toBe('What is 2+2?');
+    expect(turns[3].role).toBe('assistant');
+  });
+});
+
+describe('extractTurns dispatches by site', () => {
+  test('uses Claude extraction when site is claude', async () => {
+    useClaude();
+
+    const user = document.createElement('div');
+    user.setAttribute('data-testid', 'user-message');
+    user.textContent = 'Hello';
+    document.body.appendChild(user);
+
+    const grid = document.createElement('div');
+    grid.className = 'grid-container';
+    const copy = document.createElement('div');
+    copy.setAttribute('data-testid', 'action-bar-copy');
+    grid.appendChild(copy);
+    const resp = document.createElement('div');
+    resp.className = 'row-start-2';
+    resp.textContent = 'Hi!';
+    grid.appendChild(resp);
+    document.body.appendChild(grid);
+
+    const turns = await extractTurns();
+
+    expect(turns).toHaveLength(2);
+    expect(turns[0].role).toBe('user');
+    expect(turns[1].role).toBe('assistant');
+  });
+});
+
+describe('fixture-based Claude extraction', () => {
+  beforeEach(() => {
+    useClaude();
+    setFixture('claude-conversation.html');
+    // setFixture only sets body.innerHTML; jsdom doesn't parse <title> from body
+    document.title = 'Engineering-first AI solution - Claude';
+  });
+
+  test('counts messages in Claude fixture', () => {
+    expect(countMessages()).toBe(4); // 2 user + 2 assistant
+  });
+
+  test('extracts title from Claude fixture', () => {
+    expect(extractTitle()).toBe('Engineering-first AI solution');
+  });
+
+  test('fixture has expected Claude structure', () => {
+    const userMsgs = document.querySelectorAll('[data-testid="user-message"]');
+    const assistantMsgs = document.querySelectorAll('[data-testid="action-bar-copy"]');
+    expect(userMsgs.length).toBe(2);
+    expect(assistantMsgs.length).toBe(2);
+  });
+
+  test('extracts all turns from Claude fixture', async () => {
+    const turns = await extractTurns();
+
+    expect(turns.length).toBe(4);
+
+    // Turn 0: user
+    expect(turns[0].role).toBe('user');
+    expect(turns[0].content).toContain('help me design a system architecture');
+
+    // Turn 1: assistant with thinking + code
+    expect(turns[1].role).toBe('assistant');
+    expect(turns[1].thinking).toContain('Analyzing the request');
+    expect(turns[1].content).toContain('```python');
+    expect(turns[1].content).toContain('SystemArchitecture');
+
+    // Turn 2: user with image
+    expect(turns[2].role).toBe('user');
+    expect(turns[2].content).toContain('real-time data processing');
+    expect(turns[2].attachments).toHaveLength(1);
+
+    // Turn 3: assistant without thinking
+    expect(turns[3].role).toBe('assistant');
+    expect(turns[3].content).toContain('event-driven architecture');
+  });
+
+  test('extracts tool use from first assistant turn', async () => {
+    const turns = await extractTurns();
+    expect(turns[1].toolUse).toEqual(['Get current time']);
+  });
+});

--- a/tests/fixtures/claude-conversation.html
+++ b/tests/fixtures/claude-conversation.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Engineering-first AI solution - Claude</title>
+</head>
+<body>
+  <div class="flex-1 flex flex-col max-w-3xl">
+
+    <!-- Turn 1: User message -->
+    <div data-testid="user-message">
+      Hello Claude. Can you help me design a system architecture?
+    </div>
+
+    <!-- Turn 1: Assistant response with thinking -->
+    <div class="grid-container" style="display: grid;">
+      <div data-testid="action-bar-copy"></div>
+      <div class="row-start-1">
+        <p>Analyzing the request for system architecture design. The user wants a comprehensive approach.</p>
+        <button class="group/row">Get current time</button>
+      </div>
+      <div class="row-start-2">
+        <p>I'd be happy to help you design a system architecture. Here's a starting point:</p>
+        <pre><code data-language="python">class SystemArchitecture:
+    def __init__(self):
+        self.components = []
+
+    def add_component(self, name):
+        self.components.append(name)</code></pre>
+        <p>Let me know what specific requirements you have.</p>
+      </div>
+    </div>
+
+    <!-- Turn 2: User message -->
+    <div data-testid="user-message">
+      I need it to handle real-time data processing. Here's my current diagram:
+      <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==" alt="architecture diagram">
+    </div>
+
+    <!-- Turn 2: Assistant response without thinking -->
+    <div class="grid-container" style="display: grid;">
+      <div data-testid="action-bar-copy"></div>
+      <div class="row-start-2">
+        <p>For real-time data processing, I recommend using an event-driven architecture with message queues. The key components would be:</p>
+        <p>1. An ingestion layer for incoming data streams</p>
+        <p>2. A processing engine for transformations</p>
+        <p>3. A storage layer optimized for time-series data</p>
+      </div>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -6,6 +6,8 @@
  */
 
 const {
+  isSupportedSite,
+  getSitePrefix,
   sanitizeFilename,
   estimateExportSize,
   formatBytes,
@@ -27,6 +29,40 @@ beforeEach(() => {
 // ============================================================================
 // Pure Functions
 // ============================================================================
+
+describe('isSupportedSite', () => {
+  test('returns true for Gemini URL', () => {
+    expect(isSupportedSite('https://gemini.google.com/app/abc123')).toBe(true);
+  });
+
+  test('returns true for Claude URL', () => {
+    expect(isSupportedSite('https://claude.ai/chat/b5b2d739-81b0-4ee7-aa1a-3209c66c25d0')).toBe(true);
+  });
+
+  test('returns false for unrelated URL', () => {
+    expect(isSupportedSite('https://google.com')).toBe(false);
+  });
+
+  test('returns false for null/undefined', () => {
+    expect(isSupportedSite(null)).toBe(false);
+    expect(isSupportedSite(undefined)).toBe(false);
+    expect(isSupportedSite('')).toBe(false);
+  });
+});
+
+describe('getSitePrefix', () => {
+  test('returns gemini for Gemini URL', () => {
+    expect(getSitePrefix('https://gemini.google.com/app/abc123')).toBe('gemini');
+  });
+
+  test('returns claude for Claude URL', () => {
+    expect(getSitePrefix('https://claude.ai/chat/abc')).toBe('claude');
+  });
+
+  test('defaults to gemini for unknown URL', () => {
+    expect(getSitePrefix('https://example.com')).toBe('gemini');
+  });
+});
 
 describe('sanitizeFilename', () => {
   test('removes illegal filesystem characters', () => {
@@ -412,7 +448,7 @@ describe('handleExtract', () => {
     await handleExtract();
 
     const statusEl = document.getElementById('status');
-    expect(statusEl.textContent).toBe('Please open a Gemini conversation first.');
+    expect(statusEl.textContent).toBe('Please open a Gemini or Claude conversation first.');
     expect(statusEl.className).toBe('status error');
   });
 
@@ -422,7 +458,7 @@ describe('handleExtract', () => {
     await handleExtract();
 
     const statusEl = document.getElementById('status');
-    expect(statusEl.textContent).toBe('Please open a Gemini conversation first.');
+    expect(statusEl.textContent).toBe('Please open a Gemini or Claude conversation first.');
   });
 
   test('shows error when tab has no URL', async () => {
@@ -431,7 +467,7 @@ describe('handleExtract', () => {
     await handleExtract();
 
     const statusEl = document.getElementById('status');
-    expect(statusEl.textContent).toBe('Please open a Gemini conversation first.');
+    expect(statusEl.textContent).toBe('Please open a Gemini or Claude conversation first.');
   });
 
   test('disables button during extraction', async () => {


### PR DESCRIPTION
## Summary
- Add site-aware extraction so Clio works on both gemini.google.com and claude.ai
- Each site gets its own selectors file loaded via manifest `content_scripts`; `content.js` branches on `SELECTORS.site`
- New `selectors-claude.js` with Claude DOM selectors (`data-testid`, `.row-start-1/2`, `group/row` tool use)
- Popup URL checks and filename prefixes are now site-aware (`isSupportedSite`, `getSitePrefix`)
- Version bumped to 1.1.0

## Test plan
- [x] All 235 tests pass (11 suites), zero regressions
- [x] 22 new Claude-specific tests including fixture-based extraction
- [ ] Manual: load extension in Chrome → navigate to gemini.google.com → extract works as before
- [ ] Manual: navigate to claude.ai conversation → popup enables → extract produces zip

🤖 Generated with [Claude Code](https://claude.com/claude-code)