### PR TITLE
feat: add ChatGPT conversation extraction

### DIFF
--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -1,15 +1,16 @@
 {
   "manifest_version": 3,
   "name": "Clio",
-  "version": "1.1.0",
-  "description": "Extract full Gemini and Claude conversations to JSON with images",
+  "version": "1.2.0",
+  "description": "Extract full Gemini, Claude, and ChatGPT conversations to JSON with images",
   "permissions": [
     "activeTab",
     "downloads"
   ],
   "host_permissions": [
     "https://gemini.google.com/*",
-    "https://claude.ai/*"
+    "https://claude.ai/*",
+    "https://chatgpt.com/*"
   ],
   "action": {
     "default_popup": "src/popup.html",
@@ -31,6 +32,11 @@
     {
       "matches": ["https://claude.ai/*"],
       "js": ["src/selectors-claude.js", "src/content.js"],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["https://chatgpt.com/*"],
+      "js": ["src/selectors-chatgpt.js", "src/content.js"],
       "run_at": "document_idle"
     }
   ],

--- a/extensions/src/content.js
+++ b/extensions/src/content.js
@@ -13,7 +13,7 @@
 
 /**
  * Get the current site identifier from SELECTORS.
- * @returns {string} - 'gemini', 'claude', or 'unknown'
+ * @returns {string} - 'gemini', 'claude', 'chatgpt', or 'unknown'
  */
 function getSite() {
   return (typeof SELECTORS !== 'undefined' && SELECTORS.site) || 'unknown';
@@ -260,6 +260,9 @@ function countMessages() {
     const userMsgs = document.querySelectorAll('[data-testid="user-message"]');
     const assistantMsgs = document.querySelectorAll('[data-testid="action-bar-copy"]');
     return userMsgs.length + assistantMsgs.length;
+  }
+  if (site === 'chatgpt') {
+    return document.querySelectorAll('article[data-turn="user"], article[data-turn="assistant"]').length;
   }
   // Gemini: Count ONLY primary elements (user-query, model-response)
   // Don't use composite SELECTORS which include fallbacks that may be nested
@@ -513,9 +516,10 @@ function extractTitle() {
   let title = document.title;
   if (site === 'claude') {
     title = title.replace(/ - Claude$/, '');
-  } else {
+  } else if (site === 'gemini') {
     title = title.replace(/ - Gemini$/, '');
   }
+  // ChatGPT: title is already clean (no suffix)
   return title.trim() || 'Untitled Conversation';
 }
 
@@ -528,6 +532,11 @@ function extractConversationId() {
   if (site === 'claude') {
     // Claude URL: /chat/{uuid}
     const match = window.location.pathname.match(/\/chat\/([a-f0-9-]+)/i);
+    return match ? match[1] : 'unknown';
+  }
+  if (site === 'chatgpt') {
+    // ChatGPT URL: /c/{uuid}
+    const match = window.location.pathname.match(/\/c\/([a-f0-9-]+)/i);
     return match ? match[1] : 'unknown';
   }
   // Gemini URL: /app/{hex}
@@ -745,6 +754,89 @@ async function extractTurnsClaude() {
 }
 
 /**
+ * Extract a single ChatGPT assistant turn.
+ * ChatGPT uses article[data-turn="assistant"] with data-message-author-role inside.
+ * Reasoning is shown as "Reasoned about X for Y seconds" label (not expandable content).
+ * @param {Element} article - The article element for this assistant turn
+ * @param {number} index - Turn index
+ * @returns {Object} - Turn object
+ */
+function extractAssistantTurnChatGPT(article, index) {
+  const images = findImages(article, index);
+
+  // Extract reasoning label if present (e.g. "Reasoned about X for Y seconds")
+  let thinking = null;
+  if (SELECTORS.reasoningLabel) {
+    const reasoningEl = article.querySelector(SELECTORS.reasoningLabel);
+    if (reasoningEl) {
+      const reasonText = reasoningEl.textContent.trim();
+      if (reasonText.toLowerCase().includes('reason') || reasonText.toLowerCase().includes('thought')) {
+        thinking = reasonText;
+      }
+    }
+  }
+
+  // Extract response content from .markdown container
+  const contentSelector = SELECTORS.assistantContent || '.markdown';
+  const contentEl = article.querySelector(contentSelector);
+  const content = contentEl ? extractTextContent(contentEl) : extractTextContent(article);
+
+  // Extract model slug if available
+  let modelSlug = null;
+  const modelEl = article.querySelector('[data-message-model-slug]');
+  if (modelEl) {
+    modelSlug = modelEl.getAttribute('data-message-model-slug');
+  }
+
+  return {
+    index,
+    role: 'assistant',
+    content,
+    thinking,
+    modelSlug,
+    attachments: images.map(img => ({
+      type: 'image',
+      filename: null,
+      originalSrc: img.src
+    }))
+  };
+}
+
+/**
+ * Extract turns from a ChatGPT conversation.
+ * ChatGPT uses <article data-turn="user|assistant"> elements.
+ * @returns {Promise<Array>} - Array of turn objects
+ */
+async function extractTurnsChatGPT() {
+  const turns = [];
+  let turnIndex = 0;
+
+  const articles = document.querySelectorAll(SELECTORS.allMessages);
+
+  for (let i = 0; i < articles.length; i++) {
+    const article = articles[i];
+    const turnType = article.getAttribute('data-turn');
+
+    if (turnType === 'user') {
+      // Extract user content from .whitespace-pre-wrap or the message element
+      const contentSelector = SELECTORS.userContent || '.whitespace-pre-wrap';
+      const contentEl = article.querySelector(contentSelector);
+      const element = contentEl || article;
+      turns.push(extractUserTurn(element, turnIndex++));
+    } else if (turnType === 'assistant') {
+      turns.push(extractAssistantTurnChatGPT(article, turnIndex++));
+    }
+
+    if (i > 0 && i % 20 === 0) {
+      showProgress(`Extracting turn ${i}/${articles.length}...`);
+      await sleep(0);
+    }
+  }
+
+  return turns;
+}
+
+/**
  * Extract turns from a Gemini conversation.
  * Gemini uses .conversation-container elements with user-query and model-response inside.
  * @returns {Promise<Array>} - Array of turn objects
@@ -819,6 +911,9 @@ async function extractTurns() {
   const site = getSite();
   if (site === 'claude') {
     return extractTurnsClaude();
+  }
+  if (site === 'chatgpt') {
+    return extractTurnsChatGPT();
   }
   return extractTurnsGemini();
 }
@@ -993,7 +1088,8 @@ async function extractImages(turns) {
 async function extractConversation() {
   try {
     // Phase 0: Pre-flight checks
-    const siteName = getSite() === 'claude' ? 'Claude' : 'Gemini';
+    const siteNames = { claude: 'Claude', chatgpt: 'ChatGPT', gemini: 'Gemini' };
+    const siteName = siteNames[getSite()] || 'Unknown';
 
     if (isStreaming()) {
       return {
@@ -1126,9 +1222,11 @@ if (typeof module !== 'undefined' && module.exports) {
     extractUserTurn,
     extractAssistantTurn,
     extractAssistantTurnClaude,
+    extractAssistantTurnChatGPT,
     extractTurns,
     extractTurnsClaude,
     extractTurnsGemini,
+    extractTurnsChatGPT,
     validateSelectors,
     isStreaming,
     expandAllContent,

--- a/extensions/src/popup.js
+++ b/extensions/src/popup.js
@@ -118,7 +118,7 @@ function setButtonState(enabled, text = 'Extract Conversation') {
  */
 function isSupportedSite(url) {
   if (!url) return false;
-  return url.includes('gemini.google.com') || url.includes('claude.ai');
+  return url.includes('gemini.google.com') || url.includes('claude.ai') || url.includes('chatgpt.com');
 }
 
 /**
@@ -128,6 +128,7 @@ function isSupportedSite(url) {
  */
 function getSitePrefix(url) {
   if (url && url.includes('claude.ai')) return 'claude';
+  if (url && url.includes('chatgpt.com')) return 'chatgpt';
   return 'gemini';
 }
 
@@ -247,7 +248,7 @@ async function handleExtract() {
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
 
     if (!tab || !tab.url || !isSupportedSite(tab.url)) {
-      setStatus('Please open a Gemini or Claude conversation first.', 'error');
+      setStatus('Please open a Gemini, Claude, or ChatGPT conversation first.', 'error');
       setButtonState(true);
       hideProgress();
       return;
@@ -338,7 +339,7 @@ if (extractBtn) {
   // Check if we're on a Gemini page on load
   chrome.tabs.query({ active: true, currentWindow: true }, ([tab]) => {
     if (!tab || !tab.url || !isSupportedSite(tab.url)) {
-      setStatus('Open a Gemini or Claude conversation to extract.', 'warning');
+      setStatus('Open a Gemini, Claude, or ChatGPT conversation to extract.', 'warning');
       setButtonState(false);
     }
   });

--- a/extensions/src/selectors-chatgpt.js
+++ b/extensions/src/selectors-chatgpt.js
@@ -1,0 +1,75 @@
+/**
+ * Centralized DOM selectors for ChatGPT UI elements.
+ * Isolated here for easy maintenance when ChatGPT updates their UI.
+ *
+ * VERIFIED: 2026-02-28 from real ChatGPT DOM snapshot via Playwright
+ * Source: chatgpt.com/c/67bd8097-... (Strangler Pattern in Python)
+ */
+
+const SELECTORS = {
+  site: 'chatgpt',
+
+  // Conversation container — ChatGPT renders turns as <article> elements
+  // inside a main content area. The articles themselves are the containers.
+  conversationContainer: 'main',
+
+  // Session title — ChatGPT uses document.title directly (no suffix)
+  sessionTitle: null,
+
+  // Scroll container
+  scrollContainer: 'main [class*="overflow-y-auto"], main',
+
+  // Message elements — ChatGPT uses <article> with data-turn attribute
+  userMessage: 'article[data-turn="user"]',
+  assistantMessage: 'article[data-turn="assistant"]',
+
+  // All messages (union of user + assistant)
+  allMessages: 'article[data-turn="user"], article[data-turn="assistant"]',
+
+  // Content selectors within messages
+  // User text is inside .whitespace-pre-wrap
+  userContent: '.whitespace-pre-wrap',
+  // Assistant text is inside .markdown.prose
+  assistantContent: '.markdown',
+
+  // Expandable content — no generic expand buttons in ChatGPT
+  expandButton: null,
+
+  // Thinking/reasoning — ChatGPT shows "Reasoned about X for Y seconds"
+  // in a button inside a flex container before the response. Not expandable
+  // for o1; may be expandable for newer models.
+  thinkingToggle: null,
+  thinkingContent: null,
+  // Reasoning label — the container with "Reasoned about..." text
+  reasoningLabel: '.flex.items-start.gap-3.pb-2',
+
+  // Response content — the message element with data-message-author-role
+  responseContent: '[data-message-author-role="assistant"]',
+
+  // Code blocks — ChatGPT uses <pre> with CodeMirror inside
+  // Language label is in a sticky header div inside the pre
+  codeBlock: 'pre code, pre .cm-content',
+  codeLanguage: 'pre [class*="sticky"]',
+
+  // Images
+  image: 'img:not([class*="icon"]):not([alt="Profile image"])',
+
+  // Streaming indicator
+  streamingIndicator: 'button[aria-label*="Stop"], [data-streaming="true"], [class*="result-streaming"]',
+
+  // Loading indicator
+  loadingIndicator: '[role="progressbar"], [aria-busy="true"]',
+
+  // Model slug on assistant messages
+  modelSlug: '[data-message-model-slug]'
+};
+
+// For use in content script (non-module context)
+if (typeof window !== 'undefined') {
+  window.SELECTORS = SELECTORS;
+}
+
+// For use in tests (module context)
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { SELECTORS };
+}

--- a/tests/content-chatgpt.test.js
+++ b/tests/content-chatgpt.test.js
@@ -1,0 +1,350 @@
+/**
+ * Unit tests for ChatGPT-specific extraction in content.js.
+ *
+ * NOTE: innerHTML usage here is for test fixtures only (jsdom, not browser).
+ * No untrusted content is involved — all HTML is static test data.
+ */
+
+const {
+  getSite,
+  extractTitle,
+  extractConversationId,
+  extractTextContent,
+  extractUserTurn,
+  extractAssistantTurnChatGPT,
+  extractTurnsChatGPT,
+  extractTurns,
+  countMessages
+} = require('../extensions/src/content.js');
+
+// Load ChatGPT selectors for these tests
+const { SELECTORS: CHATGPT_SELECTORS } = require('../extensions/src/selectors-chatgpt.js');
+
+// Save original SELECTORS so we can restore after each test
+const { SELECTORS: GEMINI_SELECTORS } = require('../extensions/src/selectors.js');
+
+function useChatGPT() {
+  global.SELECTORS = CHATGPT_SELECTORS;
+  if (typeof window !== 'undefined') window.SELECTORS = CHATGPT_SELECTORS;
+}
+
+function useGemini() {
+  global.SELECTORS = GEMINI_SELECTORS;
+  if (typeof window !== 'undefined') window.SELECTORS = GEMINI_SELECTORS;
+}
+
+beforeEach(() => {
+  useChatGPT();
+  document.body.innerHTML = '';
+});
+
+afterEach(() => {
+  // Restore Gemini selectors as default (other test files expect this)
+  useGemini();
+});
+
+describe('getSite (ChatGPT)', () => {
+  test('returns chatgpt when ChatGPT selectors loaded', () => {
+    expect(getSite()).toBe('chatgpt');
+  });
+
+  test('returns gemini when Gemini selectors loaded', () => {
+    useGemini();
+    expect(getSite()).toBe('gemini');
+  });
+});
+
+describe('extractTitle (ChatGPT)', () => {
+  test('returns document title as-is (no suffix to strip)', () => {
+    document.title = 'Python lambda closure issue';
+    expect(extractTitle()).toBe('Python lambda closure issue');
+  });
+
+  test('returns Untitled Conversation for empty title', () => {
+    document.title = '';
+    expect(extractTitle()).toBe('Untitled Conversation');
+  });
+
+  test('does not strip " - Gemini" when on ChatGPT', () => {
+    document.title = 'Some title - Gemini';
+    expect(extractTitle()).toBe('Some title - Gemini');
+  });
+});
+
+describe('extractConversationId (ChatGPT)', () => {
+  const originalLocation = window.location;
+
+  afterEach(() => {
+    delete window.location;
+    window.location = originalLocation;
+  });
+
+  test('extracts UUID from ChatGPT URL', () => {
+    delete window.location;
+    window.location = { pathname: '/c/67bd8097-de20-8013-82de-4fb74629b1b3' };
+    expect(extractConversationId()).toBe('67bd8097-de20-8013-82de-4fb74629b1b3');
+  });
+
+  test('returns unknown for non-matching URL', () => {
+    delete window.location;
+    window.location = { pathname: '/settings' };
+    expect(extractConversationId()).toBe('unknown');
+  });
+});
+
+describe('countMessages (ChatGPT)', () => {
+  test('counts user and assistant articles', () => {
+    // NOTE: innerHTML with static test data only (jsdom, no browser, no untrusted content)
+    document.body.innerHTML = [
+      '<article data-turn="user">Hello</article>',
+      '<article data-turn="assistant">Hi!</article>',
+      '<article data-turn="user">Follow up</article>',
+      '<article data-turn="assistant">Sure</article>'
+    ].join('');
+    expect(countMessages()).toBe(4);
+  });
+
+  test('returns 0 when no articles', () => {
+    document.body.innerHTML = '<div>No conversation here</div>';
+    expect(countMessages()).toBe(0);
+  });
+});
+
+describe('extractAssistantTurnChatGPT', () => {
+  test('extracts markdown content from assistant turn', () => {
+    const article = document.createElement('article');
+    article.setAttribute('data-turn', 'assistant');
+    const markdown = document.createElement('div');
+    markdown.className = 'markdown prose';
+    markdown.textContent = 'The strangler pattern is used for migration.';
+    const msgDiv = document.createElement('div');
+    msgDiv.setAttribute('data-message-author-role', 'assistant');
+    msgDiv.setAttribute('data-message-model-slug', 'gpt-4o');
+    msgDiv.appendChild(markdown);
+    article.appendChild(msgDiv);
+
+    const turn = extractAssistantTurnChatGPT(article, 0);
+
+    expect(turn.role).toBe('assistant');
+    expect(turn.content).toContain('strangler pattern');
+    expect(turn.modelSlug).toBe('gpt-4o');
+    expect(turn.thinking).toBeNull();
+  });
+
+  test('extracts reasoning label from o1 turn', () => {
+    const article = document.createElement('article');
+    article.setAttribute('data-turn', 'assistant');
+
+    // Reasoning header
+    const reasoningDiv = document.createElement('div');
+    reasoningDiv.className = 'flex items-start gap-3 pb-2';
+    const btn = document.createElement('button');
+    btn.textContent = 'Reasoned about architecture for 8 seconds';
+    reasoningDiv.appendChild(btn);
+    article.appendChild(reasoningDiv);
+
+    // Response content
+    const markdown = document.createElement('div');
+    markdown.className = 'markdown prose';
+    markdown.textContent = 'Based on your diagram...';
+    const msgDiv = document.createElement('div');
+    msgDiv.setAttribute('data-message-author-role', 'assistant');
+    msgDiv.setAttribute('data-message-model-slug', 'o1');
+    msgDiv.appendChild(markdown);
+    article.appendChild(msgDiv);
+
+    const turn = extractAssistantTurnChatGPT(article, 0);
+
+    expect(turn.thinking).toContain('Reasoned about architecture');
+    expect(turn.content).toContain('Based on your diagram');
+    expect(turn.modelSlug).toBe('o1');
+  });
+
+  test('extracts code blocks from assistant turn', () => {
+    const article = document.createElement('article');
+    article.setAttribute('data-turn', 'assistant');
+    const markdown = document.createElement('div');
+    markdown.className = 'markdown';
+    const text = document.createTextNode("Here's the code:");
+    markdown.appendChild(text);
+    const pre = document.createElement('pre');
+    const code = document.createElement('code');
+    code.setAttribute('data-language', 'python');
+    code.textContent = 'print("hello")';
+    pre.appendChild(code);
+    markdown.appendChild(pre);
+    const msgDiv = document.createElement('div');
+    msgDiv.setAttribute('data-message-author-role', 'assistant');
+    msgDiv.appendChild(markdown);
+    article.appendChild(msgDiv);
+
+    const turn = extractAssistantTurnChatGPT(article, 0);
+
+    expect(turn.content).toContain('```python');
+    expect(turn.content).toContain('print("hello")');
+  });
+
+  test('extracts images from assistant turn', () => {
+    const article = document.createElement('article');
+    article.setAttribute('data-turn', 'assistant');
+    const markdown = document.createElement('div');
+    markdown.className = 'markdown';
+    const img = document.createElement('img');
+    img.src = 'data:image/png;base64,abc123';
+    markdown.appendChild(img);
+    const msgDiv = document.createElement('div');
+    msgDiv.setAttribute('data-message-author-role', 'assistant');
+    msgDiv.appendChild(markdown);
+    article.appendChild(msgDiv);
+
+    const turn = extractAssistantTurnChatGPT(article, 0);
+
+    expect(turn.attachments).toHaveLength(1);
+    expect(turn.attachments[0].type).toBe('image');
+  });
+});
+
+describe('extractTurnsChatGPT', () => {
+  test('extracts turns from ChatGPT DOM in order', async () => {
+    // Build DOM programmatically to avoid innerHTML
+    const user1 = document.createElement('article');
+    user1.setAttribute('data-turn', 'user');
+    user1.setAttribute('data-testid', 'conversation-turn-1');
+    const u1text = document.createElement('div');
+    u1text.className = 'whitespace-pre-wrap';
+    u1text.textContent = 'Hello ChatGPT';
+    user1.appendChild(u1text);
+    document.body.appendChild(user1);
+
+    const assist1 = document.createElement('article');
+    assist1.setAttribute('data-turn', 'assistant');
+    assist1.setAttribute('data-testid', 'conversation-turn-2');
+    const a1md = document.createElement('div');
+    a1md.className = 'markdown';
+    a1md.textContent = 'Hi! How can I help?';
+    assist1.appendChild(a1md);
+    const a1msg = document.createElement('div');
+    a1msg.setAttribute('data-message-author-role', 'assistant');
+    a1msg.setAttribute('data-message-model-slug', 'gpt-4o');
+    assist1.appendChild(a1msg);
+    document.body.appendChild(assist1);
+
+    const user2 = document.createElement('article');
+    user2.setAttribute('data-turn', 'user');
+    user2.setAttribute('data-testid', 'conversation-turn-3');
+    const u2text = document.createElement('div');
+    u2text.className = 'whitespace-pre-wrap';
+    u2text.textContent = 'What is 2+2?';
+    user2.appendChild(u2text);
+    document.body.appendChild(user2);
+
+    const assist2 = document.createElement('article');
+    assist2.setAttribute('data-turn', 'assistant');
+    assist2.setAttribute('data-testid', 'conversation-turn-4');
+    const a2md = document.createElement('div');
+    a2md.className = 'markdown';
+    a2md.textContent = '2+2 equals 4.';
+    assist2.appendChild(a2md);
+    const a2msg = document.createElement('div');
+    a2msg.setAttribute('data-message-author-role', 'assistant');
+    assist2.appendChild(a2msg);
+    document.body.appendChild(assist2);
+
+    const turns = await extractTurnsChatGPT();
+
+    expect(turns).toHaveLength(4);
+    expect(turns[0].role).toBe('user');
+    expect(turns[0].content).toContain('Hello ChatGPT');
+    expect(turns[1].role).toBe('assistant');
+    expect(turns[1].content).toContain('How can I help');
+    expect(turns[2].role).toBe('user');
+    expect(turns[2].content).toContain('What is 2+2');
+    expect(turns[3].role).toBe('assistant');
+    expect(turns[3].content).toContain('2+2 equals 4');
+  });
+});
+
+describe('extractTurns dispatches to ChatGPT', () => {
+  test('uses ChatGPT extraction when site is chatgpt', async () => {
+    useChatGPT();
+
+    const user = document.createElement('article');
+    user.setAttribute('data-turn', 'user');
+    user.setAttribute('data-testid', 'conversation-turn-1');
+    const utext = document.createElement('div');
+    utext.className = 'whitespace-pre-wrap';
+    utext.textContent = 'Hello';
+    user.appendChild(utext);
+    document.body.appendChild(user);
+
+    const assist = document.createElement('article');
+    assist.setAttribute('data-turn', 'assistant');
+    assist.setAttribute('data-testid', 'conversation-turn-2');
+    const amd = document.createElement('div');
+    amd.className = 'markdown';
+    amd.textContent = 'Hi!';
+    assist.appendChild(amd);
+    const amsg = document.createElement('div');
+    amsg.setAttribute('data-message-author-role', 'assistant');
+    assist.appendChild(amsg);
+    document.body.appendChild(assist);
+
+    const turns = await extractTurns();
+
+    expect(turns).toHaveLength(2);
+    expect(turns[0].role).toBe('user');
+    expect(turns[1].role).toBe('assistant');
+  });
+});
+
+describe('fixture-based ChatGPT extraction', () => {
+  beforeEach(() => {
+    useChatGPT();
+    setFixture('chatgpt-conversation.html');
+    document.title = 'Python lambda closure issue';
+  });
+
+  test('counts messages in ChatGPT fixture', () => {
+    expect(countMessages()).toBe(4); // 2 user + 2 assistant
+  });
+
+  test('extracts title from ChatGPT fixture', () => {
+    expect(extractTitle()).toBe('Python lambda closure issue');
+  });
+
+  test('fixture has expected ChatGPT structure', () => {
+    const userMsgs = document.querySelectorAll('article[data-turn="user"]');
+    const assistantMsgs = document.querySelectorAll('article[data-turn="assistant"]');
+    expect(userMsgs.length).toBe(2);
+    expect(assistantMsgs.length).toBe(2);
+  });
+
+  test('extracts all turns from ChatGPT fixture', async () => {
+    const turns = await extractTurns();
+
+    expect(turns.length).toBe(4);
+
+    // Turn 0: user
+    expect(turns[0].role).toBe('user');
+    expect(turns[0].content).toContain('strangler pattern');
+
+    // Turn 1: assistant with code (gpt-4o, no thinking)
+    expect(turns[1].role).toBe('assistant');
+    expect(turns[1].content).toContain('Strangler Pattern');
+    expect(turns[1].content).toContain('```python');
+    expect(turns[1].content).toContain('StranglerFacade');
+    expect(turns[1].thinking).toBeNull();
+    expect(turns[1].modelSlug).toBe('gpt-4o');
+
+    // Turn 2: user with image
+    expect(turns[2].role).toBe('user');
+    expect(turns[2].content).toContain('current architecture');
+    expect(turns[2].attachments).toHaveLength(1);
+
+    // Turn 3: assistant with reasoning (o1)
+    expect(turns[3].role).toBe('assistant');
+    expect(turns[3].thinking).toContain('Reasoned about strangler pattern');
+    expect(turns[3].content).toContain('API gateway');
+    expect(turns[3].modelSlug).toBe('o1');
+  });
+});

--- a/tests/fixtures/chatgpt-conversation.html
+++ b/tests/fixtures/chatgpt-conversation.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Python lambda closure issue</title>
+</head>
+<body>
+  <main>
+
+    <!-- Turn 1: User message -->
+    <article data-turn="user" data-testid="conversation-turn-1" data-turn-id="6e4495a3-31f4-41b2-b947-f4fd65accbf0" data-scroll-anchor="false">
+      <h5 class="sr-only">You said:</h5>
+      <div class="text-base my-auto mx-auto pt-3">
+        <div>
+          <div class="flex max-w-full flex-col grow">
+            <div class="min-h-8 text-message relative flex w-full flex-col items-end gap-2" data-message-author-role="user" data-message-id="6e4495a3-31f4-41b2-b947-f4fd65accbf0">
+              <div class="flex w-full flex-col gap-1 empty:hidden items-end">
+                <div class="user-message-bubble-color corner-superellipse">
+                  <div class="whitespace-pre-wrap">Can you explain the strangler pattern in software architecture?</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </article>
+
+    <!-- Turn 2: Assistant message (gpt-4o, no thinking) -->
+    <article data-turn="assistant" data-testid="conversation-turn-2" data-turn-id="1ea20cdd-dac4-4ba9-b2fa-d270c0eae306" data-scroll-anchor="false">
+      <h6 class="sr-only">ChatGPT said:</h6>
+      <div class="text-base my-auto mx-auto">
+        <div>
+          <div class="flex max-w-full flex-col grow">
+            <div class="min-h-8 text-message relative flex w-full flex-col items-end gap-2" data-message-author-role="assistant" data-message-id="4fb3a42d-55f2-4a29-928c-07d078db1fbf" data-message-model-slug="gpt-4o">
+              <div class="flex w-full flex-col gap-1 empty:hidden first:pt-[1px]">
+                <div class="markdown prose dark:prose-invert w-full wrap-break-word">
+                  <p>The <strong>Strangler Pattern</strong> is used for incrementally replacing a legacy system.</p>
+                  <p>Key benefits include reduced risk and continuous delivery.</p>
+                  <pre class="overflow-visible! px-0!">
+                    <div class="relative w-full my-4">
+                      <div>
+                        <div class="relative">
+                          <div class="h-full min-h-0 min-w-0">
+                            <div class="h-full min-h-0 min-w-0">
+                              <div class="border border-token-border-light rounded-3xl">
+                                <div class="h-full w-full overflow-clip rounded-3xl">
+                                  <div class="sticky z-2 select-none">
+                                    <div class="flex w-full items-center justify-between py-1.5 ps-4 pe-1.5 bg-token-bg-elevated-secondary">
+                                      <div class="flex text-sm font-medium text-token-text-primary">Python</div>
+                                    </div>
+                                  </div>
+                                  <div class="overflow-y-auto p-4">
+                                    <code data-language="python">class StranglerFacade:
+    def __init__(self, legacy, modern):
+        self.legacy = legacy
+        self.modern = modern
+
+    def handle(self, request):
+        if self.modern.can_handle(request):
+            return self.modern.handle(request)
+        return self.legacy.handle(request)</code>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </pre>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </article>
+
+    <!-- Turn 3: User message with image -->
+    <article data-turn="user" data-testid="conversation-turn-3" data-turn-id="93bb0fa3-90ea-47c7-9026-38c5319e7826" data-scroll-anchor="false">
+      <h5 class="sr-only">You said:</h5>
+      <div class="text-base my-auto mx-auto pt-12">
+        <div>
+          <div class="flex max-w-full flex-col grow">
+            <div class="min-h-8 text-message relative flex w-full flex-col items-end gap-2" data-message-author-role="user" data-message-id="93bb0fa3-90ea-47c7-9026-38c5319e7826">
+              <div class="flex w-full flex-col gap-1 empty:hidden items-end">
+                <div class="user-message-bubble-color corner-superellipse">
+                  <div class="whitespace-pre-wrap">Here is my current architecture. How would I apply the strangler pattern?
+                    <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==" alt="architecture diagram">
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </article>
+
+    <!-- Turn 4: Assistant message (o1, with reasoning) -->
+    <article data-turn="assistant" data-testid="conversation-turn-4" data-turn-id="d096d7e7-2eab-4483-9969-434c5f5615ea" data-scroll-anchor="false">
+      <h6 class="sr-only">ChatGPT said:</h6>
+      <div class="text-base my-auto mx-auto">
+        <div>
+          <div class="flex items-start gap-3 pb-2">
+            <div class="flex w-full flex-col">
+              <div class="flex w-full items-center justify-between">
+                <button type="button" class="group inline-flex max-w-full items-center rounded-md">
+                  <span class="text-token-text-tertiary">Reasoned about strangler pattern migration for 8 seconds</span>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div class="flex max-w-full flex-col grow">
+            <div class="min-h-8 text-message relative flex w-full flex-col items-end gap-2" data-message-author-role="assistant" data-message-id="d096d7e7-2eab-4483-9969-434c5f5615ea" data-message-model-slug="o1">
+              <div class="flex w-full flex-col gap-1 empty:hidden first:pt-[1px]">
+                <div class="markdown prose dark:prose-invert w-full wrap-break-word">
+                  <p>Based on your diagram, I'd recommend starting with the API gateway layer as your strangler facade.</p>
+                  <p>Route new traffic through the modern service while keeping the legacy system as a fallback.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </article>
+
+  </main>
+</body>
+</html>

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -39,6 +39,10 @@ describe('isSupportedSite', () => {
     expect(isSupportedSite('https://claude.ai/chat/b5b2d739-81b0-4ee7-aa1a-3209c66c25d0')).toBe(true);
   });
 
+  test('returns true for ChatGPT URL', () => {
+    expect(isSupportedSite('https://chatgpt.com/c/67bd8097-de20-8013-82de-4fb74629b1b3')).toBe(true);
+  });
+
   test('returns false for unrelated URL', () => {
     expect(isSupportedSite('https://google.com')).toBe(false);
   });
@@ -57,6 +61,10 @@ describe('getSitePrefix', () => {
 
   test('returns claude for Claude URL', () => {
     expect(getSitePrefix('https://claude.ai/chat/abc')).toBe('claude');
+  });
+
+  test('returns chatgpt for ChatGPT URL', () => {
+    expect(getSitePrefix('https://chatgpt.com/c/abc')).toBe('chatgpt');
   });
 
   test('defaults to gemini for unknown URL', () => {
@@ -448,7 +456,7 @@ describe('handleExtract', () => {
     await handleExtract();
 
     const statusEl = document.getElementById('status');
-    expect(statusEl.textContent).toBe('Please open a Gemini or Claude conversation first.');
+    expect(statusEl.textContent).toBe('Please open a Gemini, Claude, or ChatGPT conversation first.');
     expect(statusEl.className).toBe('status error');
   });
 
@@ -458,7 +466,7 @@ describe('handleExtract', () => {
     await handleExtract();
 
     const statusEl = document.getElementById('status');
-    expect(statusEl.textContent).toBe('Please open a Gemini or Claude conversation first.');
+    expect(statusEl.textContent).toBe('Please open a Gemini, Claude, or ChatGPT conversation first.');
   });
 
   test('shows error when tab has no URL', async () => {
@@ -467,7 +475,7 @@ describe('handleExtract', () => {
     await handleExtract();
 
     const statusEl = document.getElementById('status');
-    expect(statusEl.textContent).toBe('Please open a Gemini or Claude conversation first.');
+    expect(statusEl.textContent).toBe('Please open a Gemini, Claude, or ChatGPT conversation first.');
   });
 
   test('disables button during extraction', async () => {


### PR DESCRIPTION
## Summary
- Add `chatgpt.com` as third supported extraction site (alongside Gemini and Claude)
- New `selectors-chatgpt.js` with DOM selectors discovered via Playwright on real conversations
- Site-aware branching in `content.js` for ChatGPT turn extraction (`article[data-turn]`)
- Reasoning label extraction for o1/thinking models ("Reasoned about X for Y seconds")
- Model slug capture (`data-message-model-slug`) on assistant turns

## Test plan
- [x] All 256 tests pass (12 suites) — no regressions on Gemini or Claude
- [x] New `content-chatgpt.test.js` covers: getSite, extractTitle, extractConversationId, countMessages, extractAssistantTurnChatGPT (reasoning, code blocks, images), extractTurnsChatGPT, fixture-based extraction
- [x] Popup tests updated for ChatGPT URL support (`isSupportedSite`, `getSitePrefix`)
- [x] Playwright verification on real 92-turn ChatGPT conversation (mixed gpt-4o/o1 models)

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)