### PR TITLE
fix(claude): scope assistant turn extraction to per-message container (Closes #25)

### DIFF
--- a/extensions/src/content.js
+++ b/extensions/src/content.js
@@ -714,6 +714,37 @@ function extractAssistantTurnClaude(element, index) {
 }
 
 /**
+ * Resolve the per-turn container for a Claude assistant message from its
+ * action-bar-copy button. Walks up until it finds the tightest ancestor that
+ * contains the response content (.row-start-1 or .row-start-2) for THIS turn,
+ * and refuses any ancestor that contains more than one action-bar-copy button
+ * (which would indicate the ancestor wraps multiple turns).
+ *
+ * The previous implementation used element.closest('[class*="grid"]') which
+ * matched any grid-layout ancestor — on real Claude.ai DOM this often resolved
+ * to a macro container wrapping the entire conversation, causing every
+ * assistant turn to yield the first turn's content and thinking.
+ *
+ * @param {Element} copyButton - The [data-testid="action-bar-copy"] element
+ * @returns {Element} - The per-turn container
+ */
+function findClaudeAssistantContainer(copyButton) {
+  let current = copyButton.parentElement;
+  while (current && current !== document.body) {
+    const copyButtons = current.querySelectorAll(SELECTORS.assistantMessage);
+    if (copyButtons.length > 1) {
+      break;
+    }
+    if (current.querySelector(SELECTORS.responseContent) ||
+        current.querySelector(SELECTORS.thinkingContent)) {
+      return current;
+    }
+    current = current.parentElement;
+  }
+  return copyButton.parentElement || copyButton;
+}
+
+/**
  * Extract turns from a Claude conversation.
  * Claude uses a flat container with data-testid attributes to identify messages.
  * @returns {Promise<Array>} - Array of turn objects
@@ -738,9 +769,7 @@ async function extractTurnsClaude() {
     if (isUser) {
       turns.push(extractUserTurn(element, turnIndex++));
     } else {
-      // For Claude assistant messages, find the closest parent that contains
-      // both thinking and response content
-      const turnContainer = element.closest('[class*="grid"]') || element.parentElement || element;
+      const turnContainer = findClaudeAssistantContainer(element);
       turns.push(extractAssistantTurnClaude(turnContainer, turnIndex++));
     }
 

--- a/tests/content-claude.test.js
+++ b/tests/content-claude.test.js
@@ -251,6 +251,77 @@ describe('extractTurnsClaude', () => {
   });
 });
 
+describe('extractTurnsClaude with shared grid ancestor (regression #25)', () => {
+  // Reproduces the reported bug where a macro grid ancestor wraps the
+  // entire conversation. The previous implementation used
+  // element.closest('[class*="grid"]') which resolved to the macro grid for
+  // every assistant turn, causing every turn's .querySelector('.row-start-2')
+  // to return the first turn's content. Verify each assistant content and
+  // thinking field is now unique to its turn.
+  test('extracts distinct content per assistant turn when ancestors share a grid class', async () => {
+    const macroGrid = document.createElement('div');
+    macroGrid.className = 'conversation grid grid-rows-auto';
+
+    function appendUser(text) {
+      const u = document.createElement('div');
+      u.setAttribute('data-testid', 'user-message');
+      u.textContent = text;
+      macroGrid.appendChild(u);
+    }
+
+    function appendAssistant(thinkingText, responseText) {
+      const perTurn = document.createElement('div');
+      perTurn.className = 'message-layout';
+
+      const thinking = document.createElement('div');
+      thinking.className = 'row-start-1';
+      thinking.textContent = thinkingText;
+      perTurn.appendChild(thinking);
+
+      const response = document.createElement('div');
+      response.className = 'row-start-2';
+      response.textContent = responseText;
+      perTurn.appendChild(response);
+
+      const actionBar = document.createElement('div');
+      actionBar.className = 'action-bar';
+      const copy = document.createElement('button');
+      copy.setAttribute('data-testid', 'action-bar-copy');
+      actionBar.appendChild(copy);
+      perTurn.appendChild(actionBar);
+
+      macroGrid.appendChild(perTurn);
+    }
+
+    appendUser('first user message');
+    appendAssistant('first turn thinking', 'first turn response');
+    appendUser('second user message');
+    appendAssistant('second turn thinking', 'second turn response');
+    appendUser('third user message');
+    appendAssistant('third turn thinking', 'third turn response');
+
+    document.body.appendChild(macroGrid);
+
+    const turns = await extractTurnsClaude();
+
+    expect(turns).toHaveLength(6);
+
+    const assistantTurns = turns.filter(t => t.role === 'assistant');
+    expect(assistantTurns).toHaveLength(3);
+
+    expect(assistantTurns[0].content).toBe('first turn response');
+    expect(assistantTurns[1].content).toBe('second turn response');
+    expect(assistantTurns[2].content).toBe('third turn response');
+
+    expect(assistantTurns[0].thinking).toBe('first turn thinking');
+    expect(assistantTurns[1].thinking).toBe('second turn thinking');
+    expect(assistantTurns[2].thinking).toBe('third turn thinking');
+
+    const contents = new Set(assistantTurns.map(t => t.content));
+    expect(contents.size).toBe(3);
+  });
+});
+
 describe('extractTurns dispatches by site', () => {
   test('uses Claude extraction when site is claude', async () => {
     useClaude();


### PR DESCRIPTION
## Summary

- `extractTurnsClaude` used `element.closest('[class*="grid"]')` to find each assistant turn's container. On real Claude.ai DOM this matches a macro grid ancestor that wraps the entire conversation, so every assistant iteration resolved to the same container and `.querySelector('.row-start-1' / '.row-start-2')` returned the first turn's thinking/content for all turns — exactly the symptom reported in #25.
- Replaced with `findClaudeAssistantContainer`: walks up from the copy button to the tightest ancestor that contains this turn's `.row-start-1` or `.row-start-2`, rejecting any ancestor with more than one `action-bar-copy` descendant (the per-turn boundary).
- Added a regression test that plants all assistant turns inside a shared macro `grid` ancestor and asserts each turn's `content` and `thinking` are distinct.

## Test plan

- [x] `npm test` — 257 passed / 257 (was 256, +1 regression test)
- [x] New test `extractTurnsClaude with shared grid ancestor (regression #25)` fails against the old implementation and passes against the new one
- [x] Existing fixture-based Claude tests still pass (no change to the per-turn `.grid-container` case)
- [ ] Manual: load extension in Chrome, export a multi-turn Claude conversation, confirm each assistant `content` is unique

Closes #25