### PR TITLE
docs: refresh for Gemini+Claude+ChatGPT, fix dead link and typo (Closes #27)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@
 
 ## Project Overview
 
-Chrome extension for extracting full Gemini conversations to structured JSON with images. Named after the Greek Muse of History.
+Chrome extension for extracting full Gemini, Claude, and ChatGPT conversations to structured JSON with images. Named after the Greek Muse of History.
 
 ### Architecture
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # Clio
 
-A Chrome extension for extracting full Gemini conversations to structured JSON with images.
+A Chrome extension for extracting full Gemini, Claude, and ChatGPT conversations to structured JSON with images.
 
 **Clio** - Named after the Greek Muse of History.
 
 ## Features
 
-- Extracts all user inputs and Gemini responses in DOM order
+- Extracts all user inputs and assistant responses in DOM order
+- Supports Gemini (`gemini.google.com`), Claude (`claude.ai`), and ChatGPT (`chatgpt.com`)
 - Preserves code blocks with language labels
 - Captures images (screenshots, generated images)
-- Includes "Show thinking" sections when present
+- Includes thinking / reasoning sections when present
 - Handles large conversations (100+ turns) with batched processing
 - **Fail Open for images**: logs errors but continues extraction
 
@@ -30,7 +31,10 @@ A Chrome extension for extracting full Gemini conversations to structured JSON w
 
 ## Usage
 
-1. Navigate to a Gemini conversation (`https://gemini.google.com/app/...`)
+1. Navigate to a supported conversation:
+   - Gemini: `https://gemini.google.com/app/...`
+   - Claude: `https://claude.ai/chat/...`
+   - ChatGPT: `https://chatgpt.com/c/...`
 2. Wait for any streaming response to complete
 3. Click the Clio extension icon in the toolbar
 4. Click "Extract Conversation"
@@ -97,7 +101,7 @@ npm run test:e2e        # E2E tests (Playwright)
 npm run test:all        # All tests
 ```
 
-See [RUNBOOK.md](RUNBOOK.md) for detailed development instructions.
+See the [development runbook](docs/runbooks/30001-development-runbook.md) for detailed development instructions, including how to reload the extension after code changes.
 
 ## Privacy
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,6 +1,6 @@
 # Clio User Guide
 
-Clio is a Chrome extension for extracting Gemini conversations to structured JSON files with images.
+Clio is a Chrome extension for extracting Gemini, Claude, and ChatGPT conversations to structured JSON files with images.
 
 ## Installation
 
@@ -14,20 +14,23 @@ Clio is a Chrome extension for extracting Gemini conversations to structured JSO
 2. Open Chrome and go to `chrome://extensions`
 3. Enable **Developer mode** (toggle in top right)
 4. Click **Load unpacked**
-5. Select the `extension` folder inside the Clio directory
+5. Select the `extensions` folder inside the Clio directory
 6. The Clio icon will appear in your toolbar
 
 **Edge users:** Use `edge://extensions` instead.
 
 ## Basic Usage
 
-### Step 1: Open a Gemini Conversation
+### Step 1: Open a Supported Conversation
 
-Navigate to any Gemini conversation at `https://gemini.google.com/app/...`
+Navigate to any conversation on a supported site:
+- Gemini: `https://gemini.google.com/app/...`
+- Claude: `https://claude.ai/chat/...`
+- ChatGPT: `https://chatgpt.com/c/...`
 
 ### Step 2: Wait for Streaming to Complete
 
-If Gemini is still generating a response, wait for it to finish. You'll know it's done when:
+If the assistant is still generating a response, wait for it to finish. You'll know it's done when:
 - The "Stop" button disappears
 - The response text stops appearing
 
@@ -115,25 +118,28 @@ Clio includes a standalone viewer for browsing exported conversations.
 - **Bubbles**: Messages displayed in chat format
 - **Compact Mode**: Long messages are truncated (click to expand)
 - **Click to Copy**: Click any message to copy its content
-- **Thinking Sections**: Click "Show thinking" to reveal Gemini's reasoning
+- **Thinking Sections**: Click to reveal the assistant's reasoning
 
 ## Troubleshooting
 
-### "Please open a Gemini conversation first"
+### "Please open a Gemini, Claude, or ChatGPT conversation first"
 
-You're not on a Gemini page. Navigate to `https://gemini.google.com/app/...`
+You're not on a supported conversation page. Navigate to one of:
+- `https://gemini.google.com/app/...`
+- `https://claude.ai/chat/...`
+- `https://chatgpt.com/c/...`
 
 ### "Failed to load JSZip"
 
 The extension couldn't load the zip library. Try:
 1. Reload the extension in `chrome://extensions`
-2. Refresh the Gemini page
+2. Refresh the conversation page
 3. Try extraction again
 
 ### "Content script not loaded"
 
 The extension's content script didn't inject properly. Try:
-1. Refresh the Gemini page
+1. Refresh the conversation page
 2. If that doesn't work, reload the extension
 
 ### Extraction shows errors but still works
@@ -146,7 +152,7 @@ Cross-origin images or very large images may fail to extract. The conversation t
 
 ### Streaming detection issues
 
-If Clio thinks Gemini is still streaming when it's not:
+If Clio thinks the assistant is still streaming when it's not:
 1. Wait a few seconds
 2. Try extraction again
 
@@ -156,11 +162,11 @@ If Clio thinks Gemini is still streaming when it's not:
 
 - No data is sent to external servers
 - Your conversations never leave your computer
-- The extension only activates on Gemini pages
+- The extension only activates on supported assistant pages
 
 ## Tips
 
-1. **Expand "Show thinking"** before extracting if you want to capture Gemini's reasoning
+1. **Expand thinking / reasoning sections** before extracting if you want to capture the assistant's reasoning
 2. **Wait for all images to load** on the page before extracting
 3. **Large conversations** (100+ turns) may take longer to process
 4. **Use the viewer** for easier reading of exported conversations

--- a/docs/runbooks/30001-development-runbook.md
+++ b/docs/runbooks/30001-development-runbook.md
@@ -40,6 +40,17 @@ npx playwright install  # For E2E tests
 3. Click "Load unpacked"
 4. Select the `extensions/` folder
 
+### Dev Reload Loop
+
+After you change code under `extensions/`, reload the extension so Chrome picks up the new source:
+
+1. Open `chrome://extensions`
+2. Click the reload icon on the Clio card (circular arrow)
+3. Refresh the open conversation tab (`gemini.google.com`, `claude.ai`, or `chatgpt.com`) — the content script re-injects on navigation
+4. Re-run the extraction
+
+If the popup still shows stale behavior after a reload, inspect the service worker logs via the "Inspect views: service worker" link on the Clio card.
+
 ## Testing
 
 ### Unit Tests (Jest)
@@ -51,12 +62,17 @@ npm run test:watch          # Run in watch mode
 ```
 
 **Test files:**
-- `tests/content.test.js` - Content script extraction tests
+- `tests/content.test.js` - Gemini content script extraction tests
+- `tests/content-claude.test.js` - Claude content script extraction tests
+- `tests/content-chatgpt.test.js` - ChatGPT content script extraction tests
 - `tests/popup.test.js` - Popup UI and download tests
 - `tests/background.test.js` - Service worker tests
 - `tests/viewer.test.js` - Viewer component tests
 - `tests/image-extraction.test.js` - Image handling tests
 - `tests/message-passing.test.js` - Chrome messaging tests
+- `tests/auto-scroll.test.js` - Auto-scroll / lazy-load tests
+- `tests/large-conversation.test.js` - Large-conversation handling tests
+- `tests/progress-expansion.test.js` - Thinking / reasoning expansion tests
 - `tests/integration/` - Integration tests
 
 **Coverage thresholds:** 80% for branches, functions, lines, and statements.
@@ -135,7 +151,7 @@ Required sizes: 16px, 32px, 48px, 128px
 
 If extraction fails with "Content script not loaded":
 1. Reload the extension in `chrome://extensions`
-2. Refresh the Gemini page
+2. Refresh the conversation page (Gemini, Claude, or ChatGPT)
 3. Try extraction again
 
 ### Streaming Response Detection


### PR DESCRIPTION
## Summary

- Replaces Gemini-only language in README, USER_GUIDE, runbook, and the project CLAUDE.md with accurate multi-site wording (Gemini, Claude, ChatGPT) to match the v1.2.0 manifest.
- Fixes dead link in `README.md:100` that pointed to a nonexistent `RUNBOOK.md` at the repo root — now points to `docs/runbooks/30001-development-runbook.md`.
- Fixes path typo in `docs/USER_GUIDE.md:17` (`extension` → `extensions`).
- Adds a first-class **Dev Reload Loop** section to the runbook so developers changing code don't have to hunt through Troubleshooting for reload steps.
- Refreshes the runbook's test-file inventory (adds `content-claude`, `content-chatgpt`, `auto-scroll`, `large-conversation`, `progress-expansion`).

## Test plan

- [x] Docs-only change — no code touched, no tests touched
- [x] `git diff --stat` confirms only `.md` files changed
- [ ] Manual: walk through the README → runbook link chain and confirm no dead links
- [ ] Manual: follow the new "Dev Reload Loop" section on a real extension reload

Closes #27