### PR TITLE
fix(claude): enumerate assistant turns by .row-start-2, not action-bar-copy (Closes #32)

### DIFF
--- a/extensions/src/content.js
+++ b/extensions/src/content.js
@@ -257,8 +257,10 @@ function resetScrollConfig() {
 function countMessages() {
   const site = getSite();
   if (site === 'claude') {
+    // Assistant turns: one .row-start-2 per turn. Do not use action-bar-copy
+    // (appears on user messages too, inflated the count — issue #32).
     const userMsgs = document.querySelectorAll('[data-testid="user-message"]');
-    const assistantMsgs = document.querySelectorAll('[data-testid="action-bar-copy"]');
+    const assistantMsgs = document.querySelectorAll('.row-start-2');
     return userMsgs.length + assistantMsgs.length;
   }
   if (site === 'chatgpt') {
@@ -714,50 +716,50 @@ function extractAssistantTurnClaude(element, index) {
 }
 
 /**
- * Resolve the per-turn container for a Claude assistant message from its
- * action-bar-copy button. Walks up until it finds the tightest ancestor that
- * contains the response content (.row-start-1 or .row-start-2) for THIS turn,
- * and refuses any ancestor that contains more than one action-bar-copy button
- * (which would indicate the ancestor wraps multiple turns).
+ * Resolve the per-turn container for a Claude assistant turn given its
+ * .row-start-2 response-content element. Walks up from the response element
+ * until the parent would include a sibling .row-start-2 (i.e., the parent
+ * bridges turns), and returns the last single-turn ancestor.
  *
- * The previous implementation used element.closest('[class*="grid"]') which
- * matched any grid-layout ancestor — on real Claude.ai DOM this often resolved
- * to a macro container wrapping the entire conversation, causing every
- * assistant turn to yield the first turn's content and thinking.
+ * Why this shape: on real Claude DOM each assistant turn has exactly one
+ * .row-start-2; its nearest ancestors also have exactly one until we reach
+ * the conversation column, which has N (one per turn). The boundary at which
+ * the parent's .row-start-2 count flips from 1 to >1 is the per-turn
+ * container's outer edge. This keeps extraction scoped to this turn only.
  *
- * @param {Element} copyButton - The [data-testid="action-bar-copy"] element
- * @returns {Element} - The per-turn container
+ * @param {Element} responseEl - The .row-start-2 element for this turn
+ * @returns {Element} - The per-turn container (includes .row-start-1 + .row-start-2)
  */
-function findClaudeAssistantContainer(copyButton) {
-  let current = copyButton.parentElement;
+function findClaudeAssistantContainer(responseEl) {
+  let current = responseEl;
   while (current && current !== document.body) {
-    const copyButtons = current.querySelectorAll(SELECTORS.assistantMessage);
-    if (copyButtons.length > 1) {
-      break;
-    }
-    if (current.querySelector(SELECTORS.responseContent) ||
-        current.querySelector(SELECTORS.thinkingContent)) {
+    const parent = current.parentElement;
+    if (!parent || parent === document.body) break;
+    if (parent.querySelectorAll(SELECTORS.responseContent).length > 1) {
       return current;
     }
-    current = current.parentElement;
+    if (parent.querySelector(SELECTORS.userMessage)) {
+      return current;
+    }
+    current = parent;
   }
-  return copyButton.parentElement || copyButton;
+  return current || responseEl;
 }
 
 /**
  * Extract turns from a Claude conversation.
- * Claude uses a flat container with data-testid attributes to identify messages.
+ * User turns are identified by [data-testid="user-message"].
+ * Assistant turns are identified by .row-start-2 (response-content row).
  * @returns {Promise<Array>} - Array of turn objects
  */
 async function extractTurnsClaude() {
   const turns = [];
   let turnIndex = 0;
 
-  // Find all user and assistant messages and sort by DOM position
   const userMsgs = Array.from(document.querySelectorAll(SELECTORS.userMessage));
-  const assistantMsgs = Array.from(document.querySelectorAll(SELECTORS.assistantMessage));
+  const responseEls = Array.from(document.querySelectorAll(SELECTORS.assistantMessage));
 
-  const allMsgs = [...userMsgs, ...assistantMsgs].sort((a, b) => {
+  const allMsgs = [...userMsgs, ...responseEls].sort((a, b) => {
     const position = a.compareDocumentPosition(b);
     return position & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1;
   });

--- a/extensions/src/selectors-claude.js
+++ b/extensions/src/selectors-claude.js
@@ -2,8 +2,12 @@
  * Centralized DOM selectors for Claude.ai UI elements.
  * Isolated here for easy maintenance when Claude updates their UI.
  *
- * VERIFIED: 2026-02-27 from real Claude DOM snapshot via Playwright
- * Source: data/claude-b5b2d739_Engineering-first-AI-solution-for-ATT_2026-02-27.json
+ * VERIFIED: 2026-04-18 from real Claude DOM via DevTools ancestor-path dump (issue #32).
+ *
+ * assistantMessage uses `.row-start-2` (response-content row) because Claude
+ * places `[data-testid="action-bar-copy"]` on BOTH user and assistant messages,
+ * so the copy-button selector would double-count. `.row-start-2` appears
+ * exactly once per assistant turn and never inside a user-message subtree.
  */
 
 const SELECTORS = {
@@ -20,10 +24,13 @@ const SELECTORS = {
 
   // Message elements
   userMessage: '[data-testid="user-message"]',
-  assistantMessage: '[data-testid="action-bar-copy"]',
+  // One .row-start-2 per assistant turn (the response-content row).
+  // Do NOT use [data-testid="action-bar-copy"] — Claude renders that on user
+  // messages too, which caused duplicate assistant entries (issue #32).
+  assistantMessage: '.row-start-2',
 
   // All messages (union of user + assistant)
-  allMessages: '[data-testid="user-message"], [data-testid="action-bar-copy"]',
+  allMessages: '[data-testid="user-message"], .row-start-2',
 
   // Expandable content — thinking toggles in Claude
   expandButton: null, // Claude doesn't use generic expand buttons

--- a/tests/content-claude.test.js
+++ b/tests/content-claude.test.js
@@ -94,14 +94,25 @@ describe('extractConversationId (Claude)', () => {
 });
 
 describe('countMessages (Claude)', () => {
-  test('counts user and assistant messages', () => {
+  test('counts user and assistant messages (row-start-2)', () => {
     document.body.innerHTML = [
       '<div data-testid="user-message">Hello</div>',
-      '<div data-testid="action-bar-copy"></div>',
+      '<div class="row-start-2">First response</div>',
       '<div data-testid="user-message">Follow up</div>',
-      '<div data-testid="action-bar-copy"></div>'
+      '<div class="row-start-2">Second response</div>'
     ].join('');
     expect(countMessages()).toBe(4);
+  });
+
+  test('does NOT count action-bar-copy buttons (user messages have them too)', () => {
+    // Regression for #32: copy buttons appear on both user and assistant
+    // messages. Only .row-start-2 identifies an assistant turn.
+    document.body.innerHTML = [
+      '<div data-testid="user-message">Hello</div>',
+      '<button data-testid="action-bar-copy"></button>',
+      '<button data-testid="action-bar-copy"></button>'
+    ].join('');
+    expect(countMessages()).toBe(1);
   });
 
   test('returns 0 when no messages', () => {
@@ -319,6 +330,159 @@ describe('extractTurnsClaude with shared grid ancestor (regression #25)', () => 
 
     const contents = new Set(assistantTurns.map(t => t.content));
     expect(contents.size).toBe(3);
+  });
+});
+
+describe('extractTurnsClaude with real Claude DOM shape (regression #32)', () => {
+  // Reproduces the real Claude DOM structure captured via DevTools on a
+  // 19-turn live conversation:
+  //   - Conversation column <div class="flex-1 flex flex-col..."> contains
+  //     alternating user-turn and assistant-turn wrappers.
+  //   - Each user-turn wrapper holds <div data-testid="user-message"> AND
+  //     its own [data-testid="action-bar-copy"] button.
+  //   - Each assistant-turn wrapper holds .row-start-1 (thinking/toolUse)
+  //     + .row-start-2 (response) + its own [data-testid="action-bar-copy"].
+  //
+  // The previous selector (action-bar-copy) matched BOTH user and assistant
+  // copy buttons, producing 2 entries per turn with duplicated content.
+  // Fix: enumerate by .row-start-2 (one per assistant turn).
+
+  function buildRealClaudeDOM(turns) {
+    const conversationColumn = document.createElement('div');
+    conversationColumn.className = 'flex-1 flex flex-col px-4 max-w-3xl mx-auto w-full pt-1';
+
+    function actionBar() {
+      const outer = document.createElement('div');
+      outer.className = 'flex justify-start opacity-0 group-hover:opacity-100';
+      const wrap1 = document.createElement('div');
+      wrap1.className = 'text-text-300';
+      const wrap2 = document.createElement('div');
+      wrap2.className = 'text-text-300 flex items-stretch justify-between';
+      const wFit = document.createElement('div');
+      wFit.className = 'w-fit';
+      const copy = document.createElement('button');
+      copy.setAttribute('data-testid', 'action-bar-copy');
+      wFit.appendChild(copy);
+      wrap2.appendChild(wFit);
+      wrap1.appendChild(wrap2);
+      outer.appendChild(wrap1);
+      return outer;
+    }
+
+    for (const turn of turns) {
+      if (turn.role === 'user') {
+        const outer = document.createElement('div');
+        const group = document.createElement('div');
+        group.className = 'mb-1 mt-6 group';
+        const flexCol = document.createElement('div');
+        flexCol.className = 'flex flex-col items-end gap-1';
+        const userMsg = document.createElement('div');
+        userMsg.setAttribute('data-testid', 'user-message');
+        userMsg.textContent = turn.content;
+        flexCol.appendChild(userMsg);
+        flexCol.appendChild(actionBar());
+        group.appendChild(flexCol);
+        outer.appendChild(group);
+        conversationColumn.appendChild(outer);
+      } else {
+        const outer = document.createElement('div');
+        const group = document.createElement('div');
+        group.className = 'group';
+        if (turn.thinking) {
+          const think = document.createElement('div');
+          think.className = 'row-start-1';
+          think.textContent = turn.thinking;
+          group.appendChild(think);
+        }
+        if (turn.toolUse) {
+          const toolRow = document.createElement('div');
+          toolRow.className = 'row-start-1';
+          const btn = document.createElement('button');
+          btn.className = 'group/row';
+          btn.textContent = turn.toolUse;
+          toolRow.appendChild(btn);
+          group.appendChild(toolRow);
+        }
+        const resp = document.createElement('div');
+        resp.className = 'row-start-2';
+        resp.textContent = turn.content;
+        group.appendChild(resp);
+        group.appendChild(actionBar());
+        outer.appendChild(group);
+        conversationColumn.appendChild(outer);
+      }
+    }
+
+    document.body.appendChild(conversationColumn);
+  }
+
+  test('19-turn conversation yields 19 user + 19 assistant with unique content', async () => {
+    const turnSpecs = [];
+    for (let i = 1; i <= 19; i++) {
+      turnSpecs.push({ role: 'user', content: `user message ${i}` });
+      turnSpecs.push({
+        role: 'assistant',
+        content: `assistant response ${i}`,
+        thinking: `thinking for turn ${i}`,
+        toolUse: i % 3 === 0 ? `tool-call-${i}` : null
+      });
+    }
+    buildRealClaudeDOM(turnSpecs);
+
+    const turns = await extractTurnsClaude();
+
+    expect(turns).toHaveLength(38);
+
+    const userTurns = turns.filter(t => t.role === 'user');
+    const assistantTurns = turns.filter(t => t.role === 'assistant');
+    expect(userTurns).toHaveLength(19);
+    expect(assistantTurns).toHaveLength(19);
+
+    const contents = new Set(assistantTurns.map(t => t.content));
+    expect(contents.size).toBe(19);
+
+    const thinkings = new Set(assistantTurns.map(t => t.thinking));
+    expect(thinkings.size).toBe(19);
+
+    for (let i = 0; i < 19; i++) {
+      expect(assistantTurns[i].content).toBe(`assistant response ${i + 1}`);
+      expect(assistantTurns[i].thinking).toContain(`thinking for turn ${i + 1}`);
+    }
+
+    const toolUses = assistantTurns.filter(t => t.toolUse && t.toolUse.length > 0);
+    expect(toolUses.length).toBe(6);
+  });
+
+  test('user copy buttons do NOT inflate assistant count', async () => {
+    buildRealClaudeDOM([
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'hello', thinking: 'greeting' },
+      { role: 'user', content: 'how are you' },
+      { role: 'assistant', content: 'fine', thinking: 'status' }
+    ]);
+
+    const copyBtns = document.querySelectorAll('[data-testid="action-bar-copy"]');
+    expect(copyBtns.length).toBe(4);
+
+    const turns = await extractTurnsClaude();
+    expect(turns).toHaveLength(4);
+    expect(turns.filter(t => t.role === 'assistant')).toHaveLength(2);
+    expect(countMessages()).toBe(4);
+  });
+
+  test('role alternation is correct (no consecutive duplicates)', async () => {
+    buildRealClaudeDOM([
+      { role: 'user', content: 'U1' },
+      { role: 'assistant', content: 'A1', thinking: 'T1' },
+      { role: 'user', content: 'U2' },
+      { role: 'assistant', content: 'A2', thinking: 'T2' },
+      { role: 'user', content: 'U3' },
+      { role: 'assistant', content: 'A3', thinking: 'T3' }
+    ]);
+
+    const turns = await extractTurnsClaude();
+    const roles = turns.map(t => t.role);
+    expect(roles).toEqual(['user', 'assistant', 'user', 'assistant', 'user', 'assistant']);
   });
 });
 


### PR DESCRIPTION
## Summary

Previous fix in #26 was incomplete — it addressed container resolution but not enumeration. On real Claude DOM, `[data-testid="action-bar-copy"]` appears on **both** user and assistant messages, so counting copy buttons produced 2 entries per turn (e.g. 37 assistant entries from a 19-turn conversation: 19 user-copy + 18 assistant-copy). All 37 resolved to turn 1's content because the container finder then failed on the user-copy-button inputs.

Root cause verified against a real DevTools ancestor-path dump of a live 19-turn conversation (issue body of #32 has the full JSON). Key signal: `.row-start-2` appears exactly once per assistant turn and never inside a user subtree.

## Changes

- **Selector** (`selectors-claude.js`): `assistantMessage` = `.row-start-2` (was `action-bar-copy`). `allMessages` union updated. Comment explains the rationale.
- **Enumeration** (`content.js extractTurnsClaude`): iterate `.row-start-2` elements alongside user-messages, sort by DOM position, dispatch.
- **Container resolution** (`content.js findClaudeAssistantContainer`): walks up from `.row-start-2` until parent bridges turns (has multiple `.row-start-2` or contains a user-message), returns the last single-turn ancestor.
- **Counter** (`content.js countMessages` Claude branch): uses `.row-start-2` instead of copy buttons.

## Tests

- `261 / 261` pass (was 257, +4 regression tests)
- New `extractTurnsClaude with real Claude DOM shape (regression #32)` suite: builds DOM that mirrors the conversation-column → turn-wrapper → `.group` → `row-start-1/2` + action-bar layout, across 19 turns, and asserts:
  - exactly 19 user + 19 assistant turns (not 37 assistants)
  - all 19 assistant contents unique
  - all 19 thinkings unique
  - role alternation u/a/u/a… (no consecutive duplicates)
  - tool-use rows extracted for every third turn
- Additional targeted tests: `countMessages` proves `action-bar-copy` is no longer counted on user-only DOM, and the older regression test from #25 still passes (covers the generic macro-grid-ancestor case).

## Test plan

- [x] Full Jest suite green: `npm test` → 261 passed
- [ ] Manual: reload the extension, hard-refresh a Claude conversation tab, re-extract the same 19-turn conversation that produced the bug, confirm 19 unique assistant contents

Closes #32