### PR TITLE
release: bump manifest to 1.2.1 and add versioning policy (Closes #35)

### DIFF
--- a/docs/runbooks/30001-development-runbook.md
+++ b/docs/runbooks/30001-development-runbook.md
@@ -51,6 +51,18 @@ After you change code under `extensions/`, reload the extension so Chrome picks 
 
 If the popup still shows stale behavior after a reload, inspect the service worker logs via the "Inspect views: service worker" link on the Clio card.
 
+### Versioning policy
+
+Any commit that changes files under `extensions/` MUST bump `extensions/manifest.json` `version`:
+
+- Bugfix → patch bump (e.g. 1.2.0 → 1.2.1)
+- New feature (new site, new extraction field, new UI) → minor bump (e.g. 1.2.x → 1.3.0)
+- Breaking change to output schema → major bump (e.g. 1.x.x → 2.0.0)
+
+Rationale: Chrome's `chrome://extensions` card displays this version. Without a bump, a user cannot visually confirm that a reload actually picked up the new code, which makes "did my fix land?" debugging much harder (see issue #35 for the incident that motivated this rule).
+
+Docs-only PRs (no `extensions/` changes) do NOT bump the version.
+
 ## Testing
 
 ### Unit Tests (Jest)

--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Clio",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Extract full Gemini, Claude, and ChatGPT conversations to JSON with images",
   "permissions": [
     "activeTab",


### PR DESCRIPTION
## Summary

- Bumps `extensions/manifest.json` version 1.2.0 → 1.2.1 to capture the assistant-duplication fix (PR #33 / issue #32)
- Adds a Versioning policy section to the runbook so every future `extensions/` change bumps the manifest version (patch for bugfix, minor for feature, major for breaking)

## Why

During #32 the user could not visually confirm whether the fix had actually loaded because chrome://extensions displayed 1.2.0 both before and after. It turned out the local working tree had not been pulled forward, so the fix truly wasn't loaded — but the missing version bump hid that from the user until a manual file diff revealed it.

## Test plan

- [x] Manifest version shows 1.2.1 on reload
- [x] Runbook has explicit Versioning policy section
- [ ] Manual: reload extension in Chrome, confirm card shows 1.2.1

Closes #35