### PR TITLE
feat(claude): mark thinking-only assistant turns; bump 1.3.0 (Closes #37)

### DIFF
--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Clio",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Extract full Gemini, Claude, and ChatGPT conversations to JSON with images",
   "permissions": [
     "activeTab",

--- a/extensions/src/content.js
+++ b/extensions/src/content.js
@@ -701,7 +701,7 @@ function extractAssistantTurnClaude(element, index) {
     content = extractTextContent(contentClone);
   }
 
-  return {
+  const turn = {
     index,
     role: 'assistant',
     content,
@@ -713,6 +713,18 @@ function extractAssistantTurnClaude(element, index) {
       originalSrc: img.src
     }))
   };
+
+  // Mark turns whose entire response lived inside the expandable thinking
+  // section (empty .row-start-2, non-empty .row-start-1). Lets downstream
+  // consumers distinguish "assistant had nothing to say" from "assistant
+  // responded only inside the thinking panel".
+  const hasContent = !!(content && content.trim());
+  const hasThinking = !!(thinking && thinking.trim());
+  if (!hasContent && hasThinking) {
+    turn.type = 'thinking-only';
+  }
+
+  return turn;
 }
 
 /**

--- a/tests/content-claude.test.js
+++ b/tests/content-claude.test.js
@@ -209,6 +209,71 @@ describe('extractAssistantTurnClaude', () => {
     expect(turn.attachments).toHaveLength(1);
     expect(turn.attachments[0].type).toBe('image');
   });
+
+  test('marks turn as thinking-only when content empty but thinking present (issue #37)', () => {
+    const div = document.createElement('div');
+    const thinking = document.createElement('div');
+    thinking.className = 'row-start-1';
+    thinking.textContent = 'Refined email structure and incorporated confidentiality safeguards';
+    const response = document.createElement('div');
+    response.className = 'row-start-2';
+    response.textContent = '';
+    div.appendChild(thinking);
+    div.appendChild(response);
+
+    const turn = extractAssistantTurnClaude(div, 7);
+
+    expect(turn.content).toBe('');
+    expect(turn.thinking).toContain('Refined email structure');
+    expect(turn.type).toBe('thinking-only');
+  });
+
+  test('omits type field on normal turns with real content', () => {
+    const div = document.createElement('div');
+    const thinking = document.createElement('div');
+    thinking.className = 'row-start-1';
+    thinking.textContent = 'Quick thought';
+    const response = document.createElement('div');
+    response.className = 'row-start-2';
+    response.textContent = 'Here is a real answer.';
+    div.appendChild(thinking);
+    div.appendChild(response);
+
+    const turn = extractAssistantTurnClaude(div, 0);
+
+    expect(turn.content).toBe('Here is a real answer.');
+    expect(turn.type).toBeUndefined();
+  });
+
+  test('omits type field when both content and thinking are empty', () => {
+    const div = document.createElement('div');
+    const response = document.createElement('div');
+    response.className = 'row-start-2';
+    response.textContent = '';
+    div.appendChild(response);
+
+    const turn = extractAssistantTurnClaude(div, 0);
+
+    expect(turn.content).toBe('');
+    expect(turn.thinking).toBeNull();
+    expect(turn.type).toBeUndefined();
+  });
+
+  test('whitespace-only content still triggers thinking-only marker', () => {
+    const div = document.createElement('div');
+    const thinking = document.createElement('div');
+    thinking.className = 'row-start-1';
+    thinking.textContent = 'reasoning text';
+    const response = document.createElement('div');
+    response.className = 'row-start-2';
+    response.textContent = '   \n\t  ';
+    div.appendChild(thinking);
+    div.appendChild(response);
+
+    const turn = extractAssistantTurnClaude(div, 0);
+
+    expect(turn.type).toBe('thinking-only');
+  });
 });
 
 describe('extractTurnsClaude', () => {


### PR DESCRIPTION
## Summary

Adds an optional `type: "thinking-only"` field to Claude assistant turns where `content` is empty/whitespace AND `thinking` has real text. Observed on real export (Patent adjudication conversation, turns [07] and [09]) where Claude's entire response lived inside the expandable thinking panel with nothing in `.row-start-2`.

Additive change — field is omitted on normal turns, so no existing consumers are affected.

## Changes

- `extensions/src/content.js`: `extractAssistantTurnClaude` sets `turn.type = 'thinking-only'` conditionally
- `tests/content-claude.test.js`: 4 new unit tests (thinking-only marker, omission on normal turns, omission when both empty, whitespace-only content still triggers marker)
- `extensions/manifest.json`: version 1.2.1 → 1.3.0 (minor bump, new schema field, per versioning policy from #35)

## Test plan

- [x] `npm test` → 265 passed (was 261, +4)
- [ ] Manual: reload extension in Chrome, confirm card shows **1.3.0**, re-extract the Patent adjudication conversation, confirm turns [07] and [09] now have `"type": "thinking-only"` in the JSON

Closes #37