### PR TITLE
fix(claude): capture commentary prose on artifact turns; bump to 1.3.1 (Closes #39)

### DIFF
--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Clio",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Extract full Gemini, Claude, and ChatGPT conversations to JSON with images",
   "permissions": [
     "activeTab",

--- a/extensions/src/content.js
+++ b/extensions/src/content.js
@@ -686,20 +686,17 @@ function extractAssistantTurnClaude(element, index) {
     }
   }
 
-  // Extract response from .row-start-2 (preferred) or fall back to removing thinking
-  let content = '';
-  const responseEl = element.querySelector(SELECTORS.responseContent);
-  if (responseEl) {
-    content = extractTextContent(responseEl);
-  } else {
-    // Fallback: clone and remove thinking
-    const contentClone = element.cloneNode(true);
-    const thinkingClone = contentClone.querySelector(SELECTORS.thinkingContent);
-    if (thinkingClone) {
-      thinkingClone.remove();
-    }
-    content = extractTextContent(contentClone);
-  }
+  // Extract content by cloning the whole turn container and removing all
+  // .row-start-1 subtrees (there can be 2 — thinking title + tool-use row).
+  // What remains is the .row-start-2 response AND any sibling markdown
+  // content inside the response body. For artifact turns (email drafts,
+  // PDF edits, etc.) the commentary prose lives in a sibling
+  // .standard-markdown block next to an artifact widget that renders its
+  // text out-of-reach (likely iframe/shadow) — pulling only .row-start-2
+  // would silently drop that commentary. Issue #39.
+  const contentClone = element.cloneNode(true);
+  contentClone.querySelectorAll(SELECTORS.thinkingContent).forEach(el => el.remove());
+  const content = extractTextContent(contentClone);
 
   const turn = {
     index,

--- a/tests/content-claude.test.js
+++ b/tests/content-claude.test.js
@@ -274,6 +274,61 @@ describe('extractAssistantTurnClaude', () => {
 
     expect(turn.type).toBe('thinking-only');
   });
+
+  test('captures commentary prose sibling of row-start-2 (artifact turn, issue #39)', () => {
+    // Mirrors real Claude DOM for artifact turns (email drafts, PDF edits):
+    //   div (per-turn container)
+    //     div.font-claude-response
+    //       div.row-start-1 (thinking title)
+    //       div.row-start-1 (tool-use row — optional)
+    //       div.row-start-2 (artifact widget — textContent often empty
+    //                        because artifact renders via iframe/shadow)
+    //       div
+    //         div.standard-markdown
+    //           p [Model: claude-opus-4-6 | Turn ID: 4 | Time: ...]
+    //           p "The equipment ask does the heavy lifting..."
+    const turnWrapper = document.createElement('div');
+    const body = document.createElement('div');
+    body.className = 'font-claude-response';
+
+    const thinking = document.createElement('div');
+    thinking.className = 'row-start-1';
+    thinking.textContent = 'Refined email structure';
+    body.appendChild(thinking);
+
+    const toolRow = document.createElement('div');
+    toolRow.className = 'row-start-1';
+    body.appendChild(toolRow);
+
+    const artifactWidget = document.createElement('div');
+    artifactWidget.className = 'row-start-2';
+    // Artifact widget has no accessible textContent (simulating iframe/shadow)
+    body.appendChild(artifactWidget);
+
+    const commentaryWrap = document.createElement('div');
+    const markdown = document.createElement('div');
+    markdown.className = 'standard-markdown';
+    const header = document.createElement('p');
+    header.className = 'font-claude-response-body';
+    header.textContent = '[Model: claude-opus-4-6 | Turn ID: 4 | Time: 2026-04-17 09:31 CT]';
+    const para = document.createElement('p');
+    para.className = 'font-claude-response-body';
+    para.textContent = 'The equipment ask does the heavy lifting. It gives the email a natural reason to exist.';
+    markdown.appendChild(header);
+    markdown.appendChild(para);
+    commentaryWrap.appendChild(markdown);
+    body.appendChild(commentaryWrap);
+
+    turnWrapper.appendChild(body);
+
+    const turn = extractAssistantTurnClaude(turnWrapper, 7);
+
+    expect(turn.content).toContain('Turn ID: 4');
+    expect(turn.content).toContain('The equipment ask does the heavy lifting');
+    expect(turn.thinking).toContain('Refined email structure');
+    // With real commentary captured, this is NOT a thinking-only turn
+    expect(turn.type).toBeUndefined();
+  });
 });
 
 describe('extractTurnsClaude', () => {


### PR DESCRIPTION
## Summary

Claude's artifact turns (email drafts, PDF edits, Send-via-Gmail widgets) render the actual prose commentary in a `.standard-markdown` block that sits as a **sibling** of `.row-start-2` inside `.font-claude-response`. The `.row-start-2` element IS the artifact widget and its `textContent` is empty (likely iframe/shadow-rendered). Old extractor pulled only `.row-start-2` → empty content for every artifact turn.

Verified against DevTools dump from a live conversation (Turn IDs 4 and 5 of the Patent adjudication export). Chain from the commentary text node showed it living in `<p>` → `.standard-markdown` → `<div>` → `.font-claude-response` with `rs1=2, rs2=1`, siblings of the `.row-start-2` — not descendants.

## Fix

Clone the whole turn container, remove ALL `.row-start-1` subtrees (there can be 2: thinking title + tool-use row), extract text from what remains. Works for both normal turns and artifact turns with one unified rule.

## Tests

- `266 / 266` pass (was 265, +1 regression test)
- New regression test builds the artifact DOM structure (`font-claude-response` with thinking + artifact widget + sibling `standard-markdown` prose) and asserts the Turn ID header and commentary are both captured
- All existing thinking-only / normal-turn / tool-use / image-extraction tests still pass under the simplified extraction logic

## Version

`1.3.0` → `1.3.1` (bugfix = patch bump, per the policy in #35)

## Test plan

- [x] `npm test` green
- [ ] Manual: reload extension (card shows **1.3.1**), re-extract the Patent adjudication conversation, confirm Turn IDs 4 and 5 have real content starting with `[Model: claude-opus-4-6 | Turn ID: 4 ...]` and `[Model: claude-opus-4-6 | Turn ID: 5 ...]`
- [ ] Manual: confirm non-artifact turns unchanged (pick any of Turns 1, 2, 6-17)
- [ ] Manual: confirm Turn 9's 3-fragment structure preserved (PDF date-change)

Closes #39