### PR TITLE
revert: PR #40 broke normal-turn extraction; restore v1.3.0 behavior (bump 1.3.2)

### DIFF
--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Clio",
-  "version": "1.3.1",
+  "version": "1.3.0",
   "description": "Extract full Gemini, Claude, and ChatGPT conversations to JSON with images",
   "permissions": [
     "activeTab",

--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Clio",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "description": "Extract full Gemini, Claude, and ChatGPT conversations to JSON with images",
   "permissions": [
     "activeTab",

--- a/extensions/src/content.js
+++ b/extensions/src/content.js
@@ -686,17 +686,20 @@ function extractAssistantTurnClaude(element, index) {
     }
   }
 
-  // Extract content by cloning the whole turn container and removing all
-  // .row-start-1 subtrees (there can be 2 — thinking title + tool-use row).
-  // What remains is the .row-start-2 response AND any sibling markdown
-  // content inside the response body. For artifact turns (email drafts,
-  // PDF edits, etc.) the commentary prose lives in a sibling
-  // .standard-markdown block next to an artifact widget that renders its
-  // text out-of-reach (likely iframe/shadow) — pulling only .row-start-2
-  // would silently drop that commentary. Issue #39.
-  const contentClone = element.cloneNode(true);
-  contentClone.querySelectorAll(SELECTORS.thinkingContent).forEach(el => el.remove());
-  const content = extractTextContent(contentClone);
+  // Extract response from .row-start-2 (preferred) or fall back to removing thinking
+  let content = '';
+  const responseEl = element.querySelector(SELECTORS.responseContent);
+  if (responseEl) {
+    content = extractTextContent(responseEl);
+  } else {
+    // Fallback: clone and remove thinking
+    const contentClone = element.cloneNode(true);
+    const thinkingClone = contentClone.querySelector(SELECTORS.thinkingContent);
+    if (thinkingClone) {
+      thinkingClone.remove();
+    }
+    content = extractTextContent(contentClone);
+  }
 
   const turn = {
     index,

--- a/tests/content-claude.test.js
+++ b/tests/content-claude.test.js
@@ -274,61 +274,6 @@ describe('extractAssistantTurnClaude', () => {
 
     expect(turn.type).toBe('thinking-only');
   });
-
-  test('captures commentary prose sibling of row-start-2 (artifact turn, issue #39)', () => {
-    // Mirrors real Claude DOM for artifact turns (email drafts, PDF edits):
-    //   div (per-turn container)
-    //     div.font-claude-response
-    //       div.row-start-1 (thinking title)
-    //       div.row-start-1 (tool-use row — optional)
-    //       div.row-start-2 (artifact widget — textContent often empty
-    //                        because artifact renders via iframe/shadow)
-    //       div
-    //         div.standard-markdown
-    //           p [Model: claude-opus-4-6 | Turn ID: 4 | Time: ...]
-    //           p "The equipment ask does the heavy lifting..."
-    const turnWrapper = document.createElement('div');
-    const body = document.createElement('div');
-    body.className = 'font-claude-response';
-
-    const thinking = document.createElement('div');
-    thinking.className = 'row-start-1';
-    thinking.textContent = 'Refined email structure';
-    body.appendChild(thinking);
-
-    const toolRow = document.createElement('div');
-    toolRow.className = 'row-start-1';
-    body.appendChild(toolRow);
-
-    const artifactWidget = document.createElement('div');
-    artifactWidget.className = 'row-start-2';
-    // Artifact widget has no accessible textContent (simulating iframe/shadow)
-    body.appendChild(artifactWidget);
-
-    const commentaryWrap = document.createElement('div');
-    const markdown = document.createElement('div');
-    markdown.className = 'standard-markdown';
-    const header = document.createElement('p');
-    header.className = 'font-claude-response-body';
-    header.textContent = '[Model: claude-opus-4-6 | Turn ID: 4 | Time: 2026-04-17 09:31 CT]';
-    const para = document.createElement('p');
-    para.className = 'font-claude-response-body';
-    para.textContent = 'The equipment ask does the heavy lifting. It gives the email a natural reason to exist.';
-    markdown.appendChild(header);
-    markdown.appendChild(para);
-    commentaryWrap.appendChild(markdown);
-    body.appendChild(commentaryWrap);
-
-    turnWrapper.appendChild(body);
-
-    const turn = extractAssistantTurnClaude(turnWrapper, 7);
-
-    expect(turn.content).toContain('Turn ID: 4');
-    expect(turn.content).toContain('The equipment ask does the heavy lifting');
-    expect(turn.thinking).toContain('Refined email structure');
-    // With real commentary captured, this is NOT a thinking-only turn
-    expect(turn.type).toBeUndefined();
-  });
 });
 
 describe('extractTurnsClaude', () => {


### PR DESCRIPTION
## Why

PR #40 attempted to capture artifact-turn commentary by cloning the per-turn container and removing all `.row-start-1` subtrees. It tested green against a synthetic fixture, but on real Claude DOM the change broke normal turns: 18 of 20 assistant turns in the user's re-extraction came back with `content: \"\"` and `type: \"thinking-only\"`. Only the 2 artifact turns had content, and even those captured the email-widget text rather than the commentary prose that was the original target.

The synthetic fixture did not match real structure. My assumption that commentary prose is a sibling (not descendant) of `.row-start-1` was incomplete — on live Claude, normal-turn response text is apparently reachable only when you include `.row-start-1` descendants, contrary to how I modeled the DOM in the fixture.

## What this PR does

Reverts commit `1842819` (the PR #40 change) via `git revert`, restoring the exact content-extraction logic that was live in 1.3.0. Normal turns work again. Artifact turns regress to the 1.3.0 behavior (commentary still missing — issue #39 is now reopened for a correct fix).

Version bumps `1.3.1` → `1.3.2` (per the versioning policy in #35) so the reload reflects a distinct new state rather than looking like a rollback.

## Test plan

- [x] `npm test` → 265 passed (back to pre-#40 baseline)
- [ ] Manual: reload extension (card shows **1.3.2**), re-extract the Patent conversation, confirm normal turns have content again (count should match the 13:04 zip, ~17-18 turns with real content)
- [ ] Manual: confirm artifact turns [07] and [09] go back to empty content with `type: \"thinking-only\"` (the prior behavior, pending proper fix in #39)

## Next steps

Issue #39 is reopened. Need a fresh DOM diagnostic that shows the full child tree of a per-turn container for both a NORMAL turn AND an ARTIFACT turn, so the next fix is grounded in real structure, not inferred. No more speculative attempts.