### PR TITLE
fix(claude): only remove outer row-start-1, preserve nested response (Closes #39), bump 1.3.3

### DIFF
--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Clio",
-  "version": "1.3.1",
+  "version": "1.3.3",
   "description": "Extract full Gemini, Claude, and ChatGPT conversations to JSON with images",
   "permissions": [
     "activeTab",

--- a/extensions/src/content.js
+++ b/extensions/src/content.js
@@ -686,16 +686,27 @@ function extractAssistantTurnClaude(element, index) {
     }
   }
 
-  // Extract content by cloning the whole turn container and removing all
-  // .row-start-1 subtrees (there can be 2 — thinking title + tool-use row).
-  // What remains is the .row-start-2 response AND any sibling markdown
-  // content inside the response body. For artifact turns (email drafts,
-  // PDF edits, etc.) the commentary prose lives in a sibling
-  // .standard-markdown block next to an artifact widget that renders its
-  // text out-of-reach (likely iframe/shadow) — pulling only .row-start-2
-  // would silently drop that commentary. Issue #39.
+  // Extract content by cloning the turn container and removing only OUTER
+  // .row-start-1 subtrees (the thinking-title rows). Preserve any
+  // .row-start-1 nested INSIDE a .row-start-2 — on real Claude DOM the
+  // actual response body for normal turns lives in a nested
+  // .row-start-1.col-start-1 element that is a child of the outer
+  // .row-start-2. Removing it (as PR #40 did) wiped out every normal
+  // response. Issue #39.
+  //
+  // Real DOM:
+  //   font-claude-response
+  //     div.row-start-1                     <- OUTER thinking (remove)
+  //     div.row-start-2                     <- response wrapper (keep)
+  //       div.row-start-1.col-start-1...    <- INNER response body (keep)
+  //     [div > div.standard-markdown > p]   <- sibling commentary on
+  //                                            artifact turns (keep)
   const contentClone = element.cloneNode(true);
-  contentClone.querySelectorAll(SELECTORS.thinkingContent).forEach(el => el.remove());
+  contentClone.querySelectorAll(SELECTORS.thinkingContent).forEach(el => {
+    if (!el.closest(SELECTORS.responseContent)) {
+      el.remove();
+    }
+  });
   const content = extractTextContent(contentClone);
 
   const turn = {

--- a/tests/content-claude.test.js
+++ b/tests/content-claude.test.js
@@ -275,6 +275,39 @@ describe('extractAssistantTurnClaude', () => {
     expect(turn.type).toBe('thinking-only');
   });
 
+  test('preserves nested row-start-1 inside row-start-2 (real Claude normal-turn shape, issue #39)', () => {
+    // Real Claude DOM for NORMAL (non-artifact) turns:
+    //   div.font-claude-response
+    //     div.row-start-1                     (outer thinking title — remove)
+    //     div.row-start-2                     (response wrapper — keep)
+    //       div.row-start-1.col-start-1...    (INNER response body — KEEP)
+    // PR #40 blindly removed every .row-start-1 including the nested inner
+    // one, wiping out the actual response on all normal turns. The fix must
+    // remove only outer .row-start-1 (not inside a .row-start-2).
+    const body = document.createElement('div');
+    body.className = 'font-claude-response';
+
+    const outerThinking = document.createElement('div');
+    outerThinking.className = 'row-start-1';
+    outerThinking.textContent = 'Thinking title that should be removed';
+    body.appendChild(outerThinking);
+
+    const responseWrapper = document.createElement('div');
+    responseWrapper.className = 'row-start-2';
+    const innerResponse = document.createElement('div');
+    innerResponse.className = 'row-start-1 col-start-1 relative z-[2]';
+    innerResponse.textContent = '[Model: claude-opus-4-6 | Turn ID: 1 | Time: ...]\nThe real response body lives here.';
+    responseWrapper.appendChild(innerResponse);
+    body.appendChild(responseWrapper);
+
+    const turn = extractAssistantTurnClaude(body, 1);
+
+    expect(turn.content).toContain('Turn ID: 1');
+    expect(turn.content).toContain('The real response body lives here');
+    expect(turn.content).not.toContain('Thinking title that should be removed');
+    expect(turn.thinking).toContain('Thinking title that should be removed');
+  });
+
   test('captures commentary prose sibling of row-start-2 (artifact turn, issue #39)', () => {
     // Mirrors real Claude DOM for artifact turns (email drafts, PDF edits):
     //   div (per-turn container)


### PR DESCRIPTION
## Summary

Forward-fix for PR #40's catastrophic regression on normal turns (18 of 20 assistant turns returned empty content in 1.3.1). Root cause: real Claude DOM nests the actual response body in an INNER `.row-start-1.col-start-1` element that's a child of the outer `.row-start-2`. PR #40's blanket `querySelectorAll('.row-start-1').forEach(remove)` deleted both the outer thinking AND the nested response, so all normal turns came back empty.

Fix: only remove `.row-start-1` elements that are NOT descendants of any `.row-start-2`. That removes the outer thinking title while preserving the inner response body. Commentary prose on artifact turns is unaffected because it lives in a sibling markdown div inside `font-claude-response`, not inside any `.row-start-*`.

## Evidence

Real DOM (from DevTools dump):
```
font-claude-response
├── div.row-start-1                    ← outer thinking title (remove)
└── div.row-start-2                    ← response wrapper (keep)
    └── div.row-start-1.col-start-1…   ← inner response body, 25k+ chars (KEEP)
```

- v1.3.0 (just `.row-start-2` textContent): normal turns ✓, artifact turns ✗ (commentary lost)
- v1.3.1 (remove all `.row-start-1`): normal turns ✗✗ (all empty), artifact turns ✓
- v1.3.3 (remove only outer `.row-start-1`): normal turns ✓, artifact turns ✓

## Changes

- `extensions/src/content.js`: narrow the removal condition to `el.closest('.row-start-2') === null`
- `tests/content-claude.test.js`: new regression test building the real nested-`.row-start-1`-inside-`.row-start-2` shape and asserting the inner response body survives
- `extensions/manifest.json`: `1.3.1` → `1.3.3` (skipping 1.3.2 which PR #41 claimed)

## What about PR #41 (the revert)?

Can stay as-is, per your instruction. This forward-fix supersedes it. If PR #41 somehow merges first, origin/main goes to 1.3.2 with v1.3.0 behavior, and this PR would need a trivial rebase. If this one merges first, PR #41 becomes stale and can be closed during cleanup.

## Test plan

- [x] `npm test` → 267 passed (was 266, +1 regression mirroring the real DOM shape)
- [ ] Manual: reload extension (card shows **1.3.3**), re-extract the Patent conversation
- [ ] Manual: confirm ALL normal turns have real content (Turn IDs 1, 2, 3, 6, 7, 8, 9, 10-17)
- [ ] Manual: confirm Turn IDs 4 and 5 (artifact turns) now have both the email widget text AND the commentary starting with `[Model: ... Turn ID: 4 ...]`
- [ ] Manual: Turn 9's three-fragment structure still preserved

Closes #39