### PR TITLE
feat(discovery): Playwright DOM-discovery harness for Clio 2.0 sidebars

### DIFF
--- a/docs/runbooks/30001-development-runbook.md
+++ b/docs/runbooks/30001-development-runbook.md
@@ -157,6 +157,54 @@ poetry run --directory /c/Users/mcwiz/Projects/AgentOS \
 
 Required sizes: 16px, 32px, 48px, 128px
 
+### DOM Discovery (Clio 2.0 — F1, issue #47)
+
+Clio 2.0 harvests conversation lists from the sidebars of Gemini, Claude, and ChatGPT. Selectors for those sidebars are derived from real-DOM dumps produced by the Playwright harness in `tests/e2e/dom-discovery.spec.js`. Run the harness whenever:
+
+- You are starting work on sidebar-harvest issues (#51, #53) and need fresh fixtures
+- A site ships a UI change that breaks sidebar harvesting
+
+#### Running the harness
+
+```bash
+npm run test:e2e -- dom-discovery
+```
+
+The harness runs headed (Chromium only) and pauses for login on each site in sequence:
+
+1. Chromium opens on `https://gemini.google.com/app`
+2. Playwright Inspector window appears; the terminal prints a hint
+3. Log in, navigate so the conversation-list sidebar is visible
+4. Click **Resume** (▶) in the Playwright Inspector
+5. Harness runs structural analysis, saves outputs, and moves to the next site
+6. Repeat for Claude (`claude.ai/`) and ChatGPT (`chatgpt.com/`)
+
+Expected runtime: ~5–10 minutes total (mostly manual login).
+
+#### Outputs
+
+- `docs/dom-dumps/{gemini,claude,chatgpt}.json` — structured report:
+  - `scrollableContainers` — every scrollable with child-count and class fingerprints
+  - `mostLikelySidebar` — best match by repeated-child-fingerprint score
+  - `accountMenuCandidates` — avatars / account triggers (for #49 labels UI)
+  - `lazyLoad` — how child count progresses as the sidebar scrolls
+  - `urlScheme` — URL before/after clicking the first sidebar item (for conversation-id parsing in #51)
+- `tests/fixtures/sidebar-{gemini,claude,chatgpt}.html` — full page HTML snapshots consumed by S5's jsdom regression tests (#53)
+
+#### Before committing
+
+Dumps and fixtures contain real data from your account. Before `git add`:
+
+- **Scan for sensitive content:** conversation titles may be private. Either (a) sanitize titles in the HTML with find-and-replace, or (b) gitignore the specific fixture and commit a curated minimal sample.
+- **Scan for tokens:** full-page HTML may include hidden inputs with CSRF tokens. `grep -Ei "token|csrf|bearer|authorization" tests/fixtures/sidebar-*.html` to audit. Session tokens are harmless after logout but some reviewers prefer them stripped.
+
+#### Troubleshooting
+
+- **"Target closed" during page.pause():** the Inspector was closed before Resume. Re-run; leave the Inspector window open until the spec finishes.
+- **Google sign-in rejects the automation:** Gemini occasionally blocks Chromium with "this browser may not be secure". Sign in once with 2FA in the Playwright Chromium window; the session persists for the rest of the run. If it blocks repeatedly, add `channel: 'chrome'` to the chromium project in `playwright.config.js` (requires a system Chrome install).
+- **No scrollable containers detected:** the sidebar is hidden or collapsed. Expand it before clicking Resume.
+- **`mostLikelySidebar` is null in the JSON:** the heuristic requires at least 5 children with the same class fingerprint. If the sidebar has fewer items or uses per-item randomized classes, fall back to the `scrollableContainers` list and pick the candidate manually.
+
 ## Troubleshooting
 
 ### Content Script Not Loaded

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -7,7 +7,7 @@ const { defineConfig } = require('@playwright/test');
  */
 module.exports = defineConfig({
   testDir: './tests',
-  testMatch: '**/*.e2e.test.js',
+  testMatch: ['**/*.e2e.test.js', '**/*.spec.js'],
 
   /* Run tests in parallel */
   fullyParallel: true,

--- a/tests/e2e/dom-discovery.spec.js
+++ b/tests/e2e/dom-discovery.spec.js
@@ -1,0 +1,355 @@
+// @ts-check
+/**
+ * DOM discovery harness for Clio 2.0 sidebar harvesting (#47).
+ *
+ * One test per site (Gemini / Claude / ChatGPT). Each opens a headed
+ * Chromium, pauses for the user to log in and navigate to the
+ * conversation-list view, then runs structural analysis and writes:
+ *
+ *   docs/dom-dumps/{site}.json           structured report
+ *   tests/fixtures/sidebar-{site}.html   full page HTML for jsdom tests
+ *
+ * Run:  npm run test:e2e -- dom-discovery
+ * Runbook: docs/runbooks/30001-development-runbook.md §DOM Discovery (F1)
+ */
+
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+const OUT_DIR = path.join(__dirname, '..', '..', 'docs', 'dom-dumps');
+const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures');
+
+const SITES = [
+  {
+    id: 'gemini',
+    label: 'Gemini',
+    url: 'https://gemini.google.com/app',
+    hint: 'Log into Google. Ensure the Chat history sidebar (left panel) is visible.'
+  },
+  {
+    id: 'claude',
+    label: 'Claude',
+    url: 'https://claude.ai/',
+    hint: 'Log into Claude. Make sure the conversation list in the left sidebar is visible.'
+  },
+  {
+    id: 'chatgpt',
+    label: 'ChatGPT',
+    url: 'https://chatgpt.com/',
+    hint: 'Log into ChatGPT. If the sidebar is collapsed, expand it before resuming.'
+  }
+];
+
+test.use({ headless: false, viewport: { width: 1400, height: 900 } });
+
+test.beforeAll(() => {
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  fs.mkdirSync(FIXTURES_DIR, { recursive: true });
+});
+
+test.describe.serial('DOM discovery — Clio 2.0 sidebar harvesting (#47)', () => {
+  for (const site of SITES) {
+    test(site.label, async ({ page, browserName }) => {
+      test.skip(browserName !== 'chromium', 'DOM discovery is Chromium-only');
+      test.setTimeout(0);
+
+      console.log(`\n=== ${site.label.toUpperCase()} — ${site.url} ===`);
+      console.log(`Hint: ${site.hint}`);
+      console.log('After login + navigation, click Resume in the Playwright Inspector.\n');
+
+      await page.goto(site.url, { waitUntil: 'domcontentloaded' });
+      await page.pause();
+
+      const dump = await dumpSite(page);
+
+      const jsonPath = path.join(OUT_DIR, `${site.id}.json`);
+      fs.writeFileSync(jsonPath, JSON.stringify(dump, null, 2));
+
+      const htmlPath = path.join(FIXTURES_DIR, `sidebar-${site.id}.html`);
+      fs.writeFileSync(htmlPath, await page.content());
+
+      console.log(`\n✓ ${site.label}`);
+      console.log(`  Dump:       ${path.relative(process.cwd(), jsonPath)}`);
+      console.log(`  Fixture:    ${path.relative(process.cwd(), htmlPath)}`);
+      console.log(`  Scrollables: ${dump.scrollableContainers.length}`);
+      if (dump.mostLikelySidebar) {
+        const fps = dump.mostLikelySidebar.childClassFingerprints || {};
+        const top = Object.entries(fps).sort((a, b) => b[1] - a[1])[0];
+        console.log(`  Sidebar:    ${dump.mostLikelySidebarSelector}`);
+        console.log(`  Children:   ${dump.mostLikelySidebar.childCount}`);
+        if (top) console.log(`  Pattern:    ${top[1]}x "${top[0] || '(no classes)'}"`);
+      }
+      if (dump.urlScheme && dump.urlScheme.afterUrl) {
+        console.log(`  URL click:  ${dump.urlScheme.afterUrl}`);
+      } else if (dump.urlScheme && dump.urlScheme.error) {
+        console.log(`  URL click:  ERROR — ${dump.urlScheme.error}`);
+      }
+
+      expect(dump.scrollableContainers.length).toBeGreaterThan(0);
+    });
+  }
+});
+
+/**
+ * Full analysis pass over a logged-in, conversation-list-visible page.
+ * Phases: structural → lazy-load → URL-click sample.
+ */
+async function dumpSite(page) {
+  // --------------------------------------------------------------------- //
+  // Phase 1: structural analysis (side-effect free)                       //
+  // --------------------------------------------------------------------- //
+  const analysis = await page.evaluate(() => {
+    function describeElement(el, maxDepth = 6) {
+      const parts = [];
+      let cur = el;
+      while (cur && cur !== document.body && parts.length < maxDepth) {
+        let part = cur.tagName.toLowerCase();
+        if (cur.id) part += `#${cur.id}`;
+        if (cur.classList.length) {
+          const cls = Array.from(cur.classList).slice(0, 3);
+          part += '.' + cls.join('.');
+        }
+        parts.unshift(part);
+        cur = cur.parentElement;
+      }
+      return parts.join(' > ');
+    }
+
+    function ancestorChain(el, maxDepth = 10) {
+      const chain = [];
+      let cur = el;
+      while (cur && cur !== document && chain.length < maxDepth) {
+        chain.push({
+          tag: cur.tagName ? cur.tagName.toLowerCase() : null,
+          id: cur.id || null,
+          classes: Array.from(cur.classList || []),
+          role: cur.getAttribute ? cur.getAttribute('role') : null,
+          ariaLabel: cur.getAttribute ? cur.getAttribute('aria-label') : null,
+          dataTestid: cur.getAttribute ? cur.getAttribute('data-testid') : null
+        });
+        cur = cur.parentElement;
+      }
+      return chain;
+    }
+
+    const scrollables = [];
+    for (const el of document.querySelectorAll('*')) {
+      const style = getComputedStyle(el);
+      const scrolls = style.overflowY === 'auto' || style.overflowY === 'scroll';
+      if (scrolls && el.scrollHeight > el.clientHeight + 10 && el.clientHeight > 100) {
+        scrollables.push(el);
+      }
+    }
+
+    const analyzed = scrollables.map(container => {
+      const childClassFingerprints = {};
+      const childTagCounts = {};
+      for (const child of container.children) {
+        const tag = child.tagName;
+        childTagCounts[tag] = (childTagCounts[tag] || 0) + 1;
+        const fp = Array.from(child.classList).sort().join('.');
+        childClassFingerprints[fp] = (childClassFingerprints[fp] || 0) + 1;
+      }
+      const deepFingerprints = {};
+      if (container.children.length < 5 && container.children[0]) {
+        for (const grandchild of container.children[0].children) {
+          const fp = Array.from(grandchild.classList).sort().join('.');
+          deepFingerprints[fp] = (deepFingerprints[fp] || 0) + 1;
+        }
+      }
+      return {
+        selector: describeElement(container),
+        outerClasses: (container.className || '').toString().slice(0, 200),
+        childCount: container.children.length,
+        scrollHeight: container.scrollHeight,
+        clientHeight: container.clientHeight,
+        childTagCounts,
+        childClassFingerprints,
+        deepFingerprints,
+        sampleChildren: Array.from(container.children).slice(0, 3).map(c => ({
+          tag: c.tagName.toLowerCase(),
+          classes: Array.from(c.classList),
+          outerHTML: c.outerHTML.slice(0, 800)
+        })),
+        firstChildAncestorChain: container.children[0] ? ancestorChain(container.children[0]) : null
+      };
+    });
+
+    const scored = analyzed
+      .map(a => {
+        const directMax = Math.max(0, ...Object.values(a.childClassFingerprints));
+        const deepMax = Math.max(0, ...Object.values(a.deepFingerprints));
+        return Object.assign({}, a, { repeatScore: Math.max(directMax, deepMax) });
+      })
+      .sort((x, y) => y.repeatScore - x.repeatScore);
+
+    const mostLikelySidebar = scored[0] && scored[0].repeatScore >= 5 ? scored[0] : null;
+
+    const accountSelectors = [
+      'img[alt*="account" i]',
+      'img[alt*="profile" i]',
+      'img[alt*="user" i]',
+      '[aria-label*="account" i]',
+      '[aria-label*="profile" i]',
+      '[aria-label*="user menu" i]',
+      '[role="button"][aria-haspopup="menu"]',
+      'button[aria-label*="Google Account" i]'
+    ];
+    const accountCandidates = [];
+    const seenEls = new Set();
+    for (const sel of accountSelectors) {
+      let matches = [];
+      try { matches = Array.from(document.querySelectorAll(sel)); } catch (e) { continue; }
+      for (const el of matches) {
+        if (seenEls.has(el)) continue;
+        seenEls.add(el);
+        accountCandidates.push({
+          matchedSelector: sel,
+          selector: describeElement(el),
+          outerHTML: el.outerHTML.slice(0, 500),
+          ariaLabel: el.getAttribute('aria-label'),
+          alt: el.getAttribute('alt'),
+          src: el.getAttribute('src'),
+          ancestorChain: ancestorChain(el)
+        });
+        if (accountCandidates.length >= 15) break;
+      }
+      if (accountCandidates.length >= 15) break;
+    }
+
+    return {
+      url: location.href,
+      hostname: location.hostname,
+      title: document.title,
+      timestamp: new Date().toISOString(),
+      viewport: { width: window.innerWidth, height: window.innerHeight },
+      scrollableContainers: analyzed.slice(0, 10),
+      mostLikelySidebar,
+      accountMenuCandidates: accountCandidates
+    };
+  });
+
+  analysis.mostLikelySidebarSelector = analysis.mostLikelySidebar
+    ? analysis.mostLikelySidebar.selector
+    : null;
+
+  // --------------------------------------------------------------------- //
+  // Phase 2: lazy-load probe — scroll the sidebar and log child counts    //
+  // --------------------------------------------------------------------- //
+  try {
+    analysis.lazyLoad = await page.evaluate(async () => {
+      const scrollables = [];
+      for (const el of document.querySelectorAll('*')) {
+        const s = getComputedStyle(el);
+        if ((s.overflowY === 'auto' || s.overflowY === 'scroll') &&
+            el.scrollHeight > el.clientHeight + 10 &&
+            el.clientHeight > 100 &&
+            el.children.length > 5) {
+          scrollables.push(el);
+        }
+      }
+      let best = null;
+      let bestScore = 0;
+      for (const c of scrollables) {
+        const fps = {};
+        for (const ch of c.children) {
+          const fp = Array.from(ch.classList).sort().join('.');
+          fps[fp] = (fps[fp] || 0) + 1;
+        }
+        const m = Math.max(0, ...Object.values(fps));
+        if (m > bestScore) { bestScore = m; best = c; }
+      }
+      if (!best) return { error: 'no sidebar candidate for lazy-load probe' };
+
+      const history = [{ scrollTop: best.scrollTop, count: best.children.length }];
+      for (let i = 0; i < 20; i++) {
+        const prevCount = best.children.length;
+        best.scrollTop = best.scrollHeight;
+        await new Promise(r => setTimeout(r, 500));
+        const newCount = best.children.length;
+        history.push({ scrollTop: best.scrollTop, count: newCount });
+        if (newCount === prevCount && i >= 2) break;
+      }
+      return {
+        initialCount: history[0].count,
+        finalCount: history[history.length - 1].count,
+        scrollIterations: history.length - 1,
+        history
+      };
+    });
+  } catch (e) {
+    analysis.lazyLoad = { error: String(e.message || e) };
+  }
+
+  // --------------------------------------------------------------------- //
+  // Phase 3: URL scheme sample — click first sidebar item, capture URL    //
+  // --------------------------------------------------------------------- //
+  try {
+    const beforeUrl = page.url();
+    const clickResult = await page.evaluate(() => {
+      const scrollables = [];
+      for (const el of document.querySelectorAll('*')) {
+        const s = getComputedStyle(el);
+        if ((s.overflowY === 'auto' || s.overflowY === 'scroll') &&
+            el.scrollHeight > el.clientHeight + 10 &&
+            el.clientHeight > 100 &&
+            el.children.length > 5) {
+          scrollables.push(el);
+        }
+      }
+      let best = null;
+      let bestScore = 0;
+      for (const c of scrollables) {
+        const fps = {};
+        for (const ch of c.children) {
+          const fp = Array.from(ch.classList).sort().join('.');
+          fps[fp] = (fps[fp] || 0) + 1;
+        }
+        const m = Math.max(0, ...Object.values(fps));
+        if (m > bestScore) { bestScore = m; best = c; }
+      }
+      if (!best) return { clicked: false, reason: 'no sidebar candidate' };
+
+      best.scrollTop = 0;
+      const firstItem = best.children[0];
+      if (!firstItem) return { clicked: false, reason: 'sidebar has no children' };
+
+      const anchor = firstItem.querySelector('a[href]');
+      const target = anchor || firstItem;
+      target.click();
+      return {
+        clicked: true,
+        targetTag: target.tagName.toLowerCase(),
+        targetHref: anchor ? anchor.getAttribute('href') : null,
+        hadAnchor: !!anchor,
+        firstItemOuterHTML: firstItem.outerHTML.slice(0, 400)
+      };
+    });
+
+    if (clickResult.clicked) {
+      try {
+        await page.waitForFunction(u => location.href !== u, beforeUrl, { timeout: 5000 });
+        analysis.urlScheme = {
+          beforeUrl,
+          afterUrl: page.url(),
+          clickDetails: clickResult,
+          capturedAt: new Date().toISOString()
+        };
+        await page.goBack({ waitUntil: 'domcontentloaded', timeout: 10000 }).catch(() => {});
+      } catch (e) {
+        analysis.urlScheme = {
+          beforeUrl,
+          error: `URL did not change within 5s (${String(e.message || e)})`,
+          clickDetails: clickResult
+        };
+      }
+    } else {
+      analysis.urlScheme = { error: clickResult.reason };
+    }
+  } catch (e) {
+    analysis.urlScheme = { error: String(e.message || e) };
+  }
+
+  return analysis;
+}


### PR DESCRIPTION
## Summary

First concrete work on Clio 2.0 (umbrella #46). Ships the DOM-discovery harness from the roadmap's foundation epic — the sidewide unlock for S1/S5 and the rest of the sidebar-harvest work.

## What this adds

- **`tests/e2e/dom-discovery.spec.js`** — one headed Chromium test per site (Gemini, Claude, ChatGPT). Each pauses for login via `page.pause()`, then runs 3 analysis phases:
  1. **Structural** — catalogs every scrollable container with child-count, class fingerprints, sample children, and scores the most-likely sidebar by repeated-child-fingerprint count
  2. **Lazy-load** — scrolls the candidate and logs child-count progression until stable
  3. **URL scheme** — clicks the first sidebar item, captures the before/after URL, goes back
- **`playwright.config.js`** — `testMatch` extended to accept `**/*.spec.js` (idiomatic Playwright naming) alongside the existing `**/*.e2e.test.js`. Jest still uses `*.test.js` with `--testPathIgnorePatterns=e2e`, so no collision.
- **`docs/runbooks/30001-development-runbook.md`** — new "DOM Discovery" section under Key Workflows with run commands, output spec, pre-commit PII/token scanning guidance, and troubleshooting for Google anti-automation sign-in.

## What this does NOT do

- Zero `extensions/` changes — no manifest bump needed per versioning policy.
- No generated dumps / fixtures committed. Those land in a follow-up once the user runs the harness against their 4 accounts.

## How to use

```
npm run test:e2e -- dom-discovery
```

Headed Chromium opens; log in; click Resume; repeat for Claude and ChatGPT. See runbook §DOM Discovery for the full cycle.

## Test plan

- [x] `npx playwright test --list tests/e2e/dom-discovery.spec.js` enumerates 3 tests × 2 projects (firefox is runtime-skipped)
- [x] `require()` of the spec file parses cleanly (Playwright `--list` validates module load)
- [x] Runbook section renders correctly
- [ ] End-to-end manual run against all 4 accounts (intentional follow-up — produces the committed dumps + fixtures)

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)