### PR TITLE
fix(discovery): use system Chrome channel to bypass Google anti-automation block

### DIFF
--- a/docs/runbooks/30001-development-runbook.md
+++ b/docs/runbooks/30001-development-runbook.md
@@ -164,6 +164,10 @@ Clio 2.0 harvests conversation lists from the sidebars of Gemini, Claude, and Ch
 - You are starting work on sidebar-harvest issues (#51, #53) and need fresh fixtures
 - A site ships a UI change that breaks sidebar harvesting
 
+#### Prerequisites
+
+- **System Chrome installed.** The harness uses `channel: 'chrome'` to launch your real Chrome install, not Playwright's bundled Chromium. Google's anti-automation fingerprinting blocks sign-in on bundled Chromium with "This browser or app may not be secure" — the Chrome channel is friendlier. On Windows, any standard Chrome install works; no extra setup.
+
 #### Running the harness
 
 ```bash
@@ -174,19 +178,18 @@ The `--debug` flag baked into this script forces the **Playwright Inspector** to
 
 **What you'll see** — the command opens **two separate windows**:
 
-1. **Chromium browser** — a normal-looking browser window navigated to the target site. This is where you log in and interact with the page.
+1. **Chrome browser** — a normal-looking browser window. Starts at `about:blank` (see workflow below), then navigates to the target site. This is where you log in and interact with the page.
 2. **Playwright Inspector** — a smaller window alongside the browser. Looks like a debugger: a toolbar across the top with playback controls (▶ Resume, ⏸ Pause, step-over), and a panel showing the paused line of script.
 
-The **Resume** button is the large green play triangle (▶) at the left of the Inspector's toolbar. Clicking it is what tells the paused script "OK, proceed."
+The **Resume** button is the large green play triangle (▶) at the left of the Inspector's toolbar, keyboard shortcut **F8**. Clicking it tells the paused script "OK, proceed."
 
-Per-site workflow:
+**You will click Resume twice per site** because `--debug` mode pauses once at the start of the test AND again at the explicit `await page.pause()` line:
 
-1. Chromium opens on `https://gemini.google.com/app` (first site in sequence)
-2. Playwright Inspector opens alongside — the script is paused at `await page.pause()`
-3. Log into the browser, make sure the conversation-list sidebar is visible (expand it if collapsed)
-4. Switch to the Inspector window and click ▶ **Resume**
-5. Script runs structural analysis on the live page, writes outputs, closes the browser, opens the next site
-6. Repeat for Claude (`claude.ai/`) and ChatGPT (`chatgpt.com/`)
+1. Chrome opens at `about:blank`; Inspector is paused before the first `page.goto` line
+2. **Click ▶ Resume (or F8)** — the browser navigates to `https://gemini.google.com/app` (or the next pending site), then the script hits `page.pause()` and pauses again
+3. Log into Google in the Chrome window; make sure the Chat history sidebar on the left is visible (expand it if collapsed)
+4. **Click ▶ Resume again** — the analysis runs on the live page, writes outputs, closes the browser, and opens the next site
+5. Repeat the two-click pattern for Claude (`claude.ai/`) and ChatGPT (`chatgpt.com/`)
 
 Expected runtime: ~5–10 minutes total (mostly manual login).
 
@@ -211,7 +214,8 @@ Dumps and fixtures contain real data from your account. Before `git add`:
 
 - **Inspector window doesn't open:** The `test:e2e:dom-discovery` script passes `--debug`, which is what triggers Inspector. If only the browser opens and you see no separate control window, confirm you ran `npm run test:e2e:dom-discovery` (not the plain `npm run test:e2e`). Running `PWDEBUG=1 npm run test:e2e -- dom-discovery` is an equivalent fallback. If neither works, your Playwright install may be missing its inspector UI — try `npx playwright install` to refresh.
 - **"Target closed" during `page.pause()`:** You closed the Inspector window before clicking Resume. Re-run; leave the Inspector open until the whole spec finishes (it closes automatically at the end).
-- **Google sign-in rejects the automation:** Gemini occasionally blocks Chromium with "this browser may not be secure". Sign in once with 2FA in the Playwright Chromium window; the session persists for the rest of the run. If it blocks repeatedly, add `channel: 'chrome'` to the chromium project in `playwright.config.js` (requires a system Chrome install).
+- **Google sign-in still blocks with "browser may not be secure":** The harness already uses `channel: 'chrome'` + `--disable-blink-features=AutomationControlled` to dodge this. If it still fires, possibilities: (a) no system Chrome installed — install Chrome and retry; (b) a custom Chrome policy is disallowing automation — check `chrome://policy` for `BrowserSignin` / `RemoteDebuggingAllowed` restrictions; (c) Google is escalating — try launching with a persistent user-data-dir so you're recognized as a returning user (would require spec changes).
+- **"Chrome browser not found" at launch:** `channel: 'chrome'` requires a system Chrome install. On Windows, install Chrome from https://www.google.com/chrome/ and retry.
 - **No scrollable containers detected:** the sidebar is hidden or collapsed in the page when you clicked Resume. Expand it first, then re-run.
 - **`mostLikelySidebar` is null in the JSON:** the heuristic requires at least 5 children with the same class fingerprint. If the sidebar has fewer items or uses per-item randomized classes, fall back to the `scrollableContainers` list in the dump and pick the candidate manually.
 

--- a/tests/e2e/dom-discovery.spec.js
+++ b/tests/e2e/dom-discovery.spec.js
@@ -41,7 +41,19 @@ const SITES = [
   }
 ];
 
-test.use({ headless: false, viewport: { width: 1400, height: 900 } });
+// channel: 'chrome' launches the user's installed system Chrome instead of
+// Playwright's bundled Chromium — Google's anti-automation fingerprinting
+// blocks sign-in on bundled Chromium ("This browser or app may not be
+// secure"). --disable-blink-features=AutomationControlled removes the
+// navigator.webdriver signal that Playwright sets by default.
+test.use({
+  headless: false,
+  viewport: { width: 1400, height: 900 },
+  channel: 'chrome',
+  launchOptions: {
+    args: ['--disable-blink-features=AutomationControlled']
+  }
+});
 
 test.beforeAll(() => {
   fs.mkdirSync(OUT_DIR, { recursive: true });


### PR DESCRIPTION
## Summary

First live run of the DOM-discovery harness (#47) hit Google's anti-automation block on `gemini.google.com/signin`:

> Couldn't sign you in. This browser or app may not be secure.

The block fires before any credential entry, so the previous runbook guidance ("sign in once with 2FA") didn't apply.

## Fix

- **`tests/e2e/dom-discovery.spec.js`** — `test.use({ channel: 'chrome', launchOptions: { args: ['--disable-blink-features=AutomationControlled'] } })` launches the user's installed system Chrome instead of Playwright's bundled Chromium, and strips the `navigator.webdriver` fingerprint. Scoped to this spec — other E2E tests continue using bundled Chromium.
- **Runbook** — new Prerequisites block (system Chrome required), "What you'll see" says Chrome, workflow section documents the two-Resume-clicks-per-site pattern (first runs `page.goto`, second resumes past `page.pause()`), troubleshooting updated for the residual cases.

## Test plan

- [x] `npx playwright test --list tests/e2e/dom-discovery.spec.js` enumerates cleanly
- [x] `test.use` config parses with the new channel + launchOptions keys
- [ ] End-to-end: user logs into Gemini through the Chrome-channel window without hitting the "browser may not be secure" page

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)