### PR TITLE
fix(discovery): persistent browser profiles — log in once per site, forever

### DIFF
--- a/docs/adrs/0201-playwright-system-chrome-channel.md
+++ b/docs/adrs/0201-playwright-system-chrome-channel.md
@@ -1,8 +1,10 @@
 # 0201 - ADR: System Chrome Channel for Playwright Automation Against Anti-Automation-Gated Sites
 
-**Status:** Implemented
+**Status:** Implemented (Option A + Option B — see §7)
 **Date:** 2026-04-22
 **Categories:** Infrastructure, Process
+
+> **Update 2026-04-22 (same day):** Option B (persistent user-data-dir) was escalated into implementation alongside Option A after first live run showed that per-run login was untenable — the Claude test died mid-navigation and would have required re-login anyway. Both options now ship in `tests/e2e/dom-discovery.spec.js` (issue #81). Section 7 reflects the current state; Section 3 Option B is no longer "reserved."
 
 ## 1. Context
 
@@ -137,20 +139,32 @@ Trade-offs accepted:
 
 ## 7. Implementation
 
-- **Related Issues:** #47 (DOM-discovery harness), #75 (this fix), #76 (PR shipping the fix), #77 (this ADR)
+- **Related Issues:** #47 (DOM-discovery harness), #75 (Option A fix), #76 (PR shipping Option A), #77 (this ADR), #81 (Option B escalation), #79 (instrumentation)
 - **Related ADRs:** AssemblyZero ADR-0209 (Playwright persistent context for extension testing) — complementary, different scope. AssemblyZero ADR-0216 mirrors this ADR for cross-project reference.
-- **Status:** Complete — shipped as Clio PR #76, merged 2026-04-22
-- **Pattern for new specs that need it:**
+- **Status:** Complete — Option A shipped in PR #76; Option B shipped in the PR closing #81 (both merged 2026-04-22).
+- **Why both options ship together:** Option A (system Chrome channel) is needed to pass the fingerprint check at the sign-in page. Option B (persistent user-data-dir) is needed so login survives across test runs — without it, a mid-run failure requires re-login on the next attempt, which is untenable given sign-in time + occasional 2FA / CAPTCHA friction. Neither option alone is sufficient for a reliable harness; the two stack.
+- **Pattern for new specs that need both:**
   ```js
-  test.use({
+  const { chromium } = require('@playwright/test');
+  const os = require('os');
+  const path = require('path');
+
+  // Inside your test:
+  const userDataDir = path.join(os.homedir(), '.<project>-profiles', site.id);
+  const context = await chromium.launchPersistentContext(userDataDir, {
     channel: 'chrome',
-    launchOptions: {
-      args: ['--disable-blink-features=AutomationControlled']
-    }
+    headless: false,
+    args: ['--disable-blink-features=AutomationControlled']
   });
+  // ... use context.pages()[0] or context.newPage() ...
+  await context.close();
   ```
-- **When to apply:** any Playwright spec that must sign into Google, Microsoft, or comparable anti-automation-gated provider. Do NOT apply to specs that don't need it — bundled Chromium is faster and needs no external install.
-- **Escalation:** if this pattern ever fails (sign-in re-blocks), move the affected spec to Option B — persistent user-data-dir with pre-authenticated profile. File a follow-up ADR superseding this one if escalation becomes the default.
+- **When to apply:** any Playwright spec that must sign into Google, Microsoft, or comparable anti-automation-gated provider AND runs often enough that per-run login is a cost. Do NOT apply to specs that don't need it — bundled Chromium is faster and needs no external install.
+- **Profile location convention:** user home dir (`~/.<project>-profiles/`), not repo-local, not `test-results/`. Outside the repo so reclones and `git clean` don't wipe sessions; outside test-results so test-result churn doesn't wipe sessions either.
+- **Further escalation paths** (if both options still fail):
+  - Pin a specific Chrome binary instead of the system default (`executablePath`) — defends against auto-update fingerprint drift
+  - Add more launch args (e.g. `--disable-automation`, `--disable-web-security` only when essential)
+  - Route through an authenticated residential proxy (last resort; significant complexity)
 
 ## 8. References
 

--- a/docs/runbooks/30001-development-runbook.md
+++ b/docs/runbooks/30001-development-runbook.md
@@ -168,17 +168,29 @@ Clio 2.0 harvests conversation lists from the sidebars of Gemini, Claude, and Ch
 
 - **System Chrome installed.** The harness uses `channel: 'chrome'` to launch your real Chrome install, not Playwright's bundled Chromium. Google's anti-automation fingerprinting blocks sign-in on bundled Chromium with "This browser or app may not be secure" — the Chrome channel is friendlier. On Windows, any standard Chrome install works; no extra setup.
 
+#### Persistent login profiles
+
+Each site's login is cached to disk so **you only log in once per site, forever** (until you explicitly clear the profile):
+
+- Profile location: `~/.clio-profiles/{gemini,claude,chatgpt}/` (outside the repo; survives reclones)
+- First run for a site: Chrome opens on a fresh profile, you log in manually
+- Subsequent runs: Chrome opens, profile is already authenticated, the site loads straight to the conversation list
+- Clear one site to force re-login: `rm -rf ~/.clio-profiles/{site}/`
+- Clear all: `rm -rf ~/.clio-profiles/`
+
+If a site ships a change that invalidates saved sessions (forced logout, security alert), you'll see the login page on next run; log in again and the profile re-authenticates.
+
 #### Running the harness
 
 ```bash
 npm run test:e2e:dom-discovery
 ```
 
-The `--debug` flag baked into this script forces the **Playwright Inspector** to open. That's what gives you the Resume button you'll need to hand control back to the script after login.
+The `--debug` flag baked into this script forces the **Playwright Inspector** to open. That's what gives you the Resume button you'll need to hand control back to the script.
 
 **What you'll see** — the command opens **two separate windows**:
 
-1. **Chrome browser** — a normal-looking browser window. Starts at `about:blank` (see workflow below), then navigates to the target site. This is where you log in and interact with the page.
+1. **Chrome browser** — a normal-looking browser window. Starts at `about:blank`, then navigates to the target site. On first run, you'll see the site's login page. On subsequent runs, you'll land in the logged-in conversation list directly.
 2. **Playwright Inspector** — a smaller window alongside the browser. Looks like a debugger: a toolbar across the top with playback controls (▶ Resume, ⏸ Pause, step-over), and a panel showing the paused line of script.
 
 The **Resume** button is the large green play triangle (▶) at the left of the Inspector's toolbar, keyboard shortcut **F8**. Clicking it tells the paused script "OK, proceed."
@@ -186,12 +198,12 @@ The **Resume** button is the large green play triangle (▶) at the left of the 
 **You will click Resume twice per site** because `--debug` mode pauses once at the start of the test AND again at the explicit `await page.pause()` line:
 
 1. Chrome opens at `about:blank`; Inspector is paused before the first `page.goto` line
-2. **Click ▶ Resume (or F8)** — the browser navigates to `https://gemini.google.com/app` (or the next pending site), then the script hits `page.pause()` and pauses again
-3. Log into Google in the Chrome window; make sure the Chat history sidebar on the left is visible (expand it if collapsed)
+2. **Click ▶ Resume (or F8)** — the browser navigates to the site
+3. **First run:** log into the site. **Subsequent runs:** verify the conversation-list sidebar is visible (expand it if collapsed). Either way, the script is now paused at `page.pause()`.
 4. **Click ▶ Resume again** — the analysis runs on the live page, writes outputs, closes the browser, and opens the next site
-5. Repeat the two-click pattern for Claude (`claude.ai/`) and ChatGPT (`chatgpt.com/`)
+5. Repeat the two-click pattern for each remaining site
 
-Expected runtime: ~5–10 minutes total (mostly manual login).
+Expected runtime on first run: ~5–10 minutes (mostly manual login). Subsequent runs: ~1–2 minutes (no login, just clicking Resume and waiting for analysis).
 
 #### Outputs
 

--- a/tests/e2e/dom-discovery.spec.js
+++ b/tests/e2e/dom-discovery.spec.js
@@ -3,142 +3,166 @@
  * DOM discovery harness for Clio 2.0 sidebar harvesting (#47).
  *
  * One test per site (Gemini / Claude / ChatGPT). Each opens a headed
- * Chromium, pauses for the user to log in and navigate to the
- * conversation-list view, then runs structural analysis and writes:
+ * Chrome, pauses for the user to log in (first run only) and navigate
+ * to the conversation-list view, then runs structural analysis and
+ * writes:
  *
  *   docs/dom-dumps/{site}.json           structured report
  *   tests/fixtures/sidebar-{site}.html   full page HTML for jsdom tests
  *
- * Run:  npm run test:e2e -- dom-discovery
+ * Login is persistent: each site has its own Chrome profile at
+ *   ~/.clio-profiles/{site}/
+ * First run asks for login; every subsequent run uses the cached
+ * session and skips straight past the sign-in flow. Clear a specific
+ * profile to force re-login: `rm -rf ~/.clio-profiles/{site}/`.
+ *
+ * Run:  npm run test:e2e:dom-discovery
  * Runbook: docs/runbooks/30001-development-runbook.md §DOM Discovery (F1)
+ * ADR: docs/adrs/0201-playwright-system-chrome-channel.md
+ *      (this spec uses Option A — channel:chrome — AND Option B —
+ *      persistent user-data-dir — from that ADR)
  */
 
-const { test, expect } = require('@playwright/test');
+const { test, expect, chromium } = require('@playwright/test');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const OUT_DIR = path.join(__dirname, '..', '..', 'docs', 'dom-dumps');
 const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures');
+const PROFILES_ROOT = path.join(os.homedir(), '.clio-profiles');
 
 const SITES = [
   {
     id: 'gemini',
     label: 'Gemini',
     url: 'https://gemini.google.com/app',
-    hint: 'Log into Google. Ensure the Chat history sidebar (left panel) is visible.'
+    hint: 'Log into Google (first run only). Ensure the Chat history sidebar (left panel) is visible.'
   },
   {
     id: 'claude',
     label: 'Claude',
     url: 'https://claude.ai/',
-    hint: 'Log into Claude. Make sure the conversation list in the left sidebar is visible.'
+    hint: 'Log into Claude (first run only). Make sure the conversation list in the left sidebar is visible.'
   },
   {
     id: 'chatgpt',
     label: 'ChatGPT',
     url: 'https://chatgpt.com/',
-    hint: 'Log into ChatGPT. If the sidebar is collapsed, expand it before resuming.'
+    hint: 'Log into ChatGPT (first run only). If the sidebar is collapsed, expand it before resuming.'
   }
 ];
-
-// channel: 'chrome' launches the user's installed system Chrome instead of
-// Playwright's bundled Chromium — Google's anti-automation fingerprinting
-// blocks sign-in on bundled Chromium ("This browser or app may not be
-// secure"). --disable-blink-features=AutomationControlled removes the
-// navigator.webdriver signal that Playwright sets by default.
-//
-// trace/video are unconditionally on for this spec: it runs rarely,
-// interactively, and any failure is expensive to reproduce (requires
-// re-login). The forensic value on the first failure justifies the
-// trace/video cost. See docs/runbooks/30001-development-runbook.md
-// §DOM Discovery troubleshooting for how to open a saved trace.
-test.use({
-  headless: false,
-  viewport: { width: 1400, height: 900 },
-  channel: 'chrome',
-  launchOptions: {
-    args: ['--disable-blink-features=AutomationControlled']
-  },
-  trace: 'on',
-  video: 'on'
-});
 
 test.beforeAll(() => {
   fs.mkdirSync(OUT_DIR, { recursive: true });
   fs.mkdirSync(FIXTURES_DIR, { recursive: true });
+  fs.mkdirSync(PROFILES_ROOT, { recursive: true });
 });
 
 test.describe.serial('DOM discovery — Clio 2.0 sidebar harvesting (#47)', () => {
   for (const site of SITES) {
-    test(site.label, async ({ page, browserName }) => {
+    test(site.label, async ({ browserName }, testInfo) => {
       test.skip(browserName !== 'chromium', 'DOM discovery is Chromium-only');
       test.setTimeout(0);
 
-      console.log(`\n=== ${site.label.toUpperCase()} — ${site.url} ===`);
-      console.log(`Hint: ${site.hint}`);
-      console.log('After login + navigation, click Resume in the Playwright Inspector.\n');
+      // Per-site persistent profile — login survives across runs.
+      // ADR-0201 Option B implementation; supersedes the default
+      // Playwright page fixture for this spec (see #81).
+      const userDataDir = path.join(PROFILES_ROOT, site.id);
+      fs.mkdirSync(userDataDir, { recursive: true });
 
-      await page.goto(site.url, { waitUntil: 'domcontentloaded' });
-      await page.pause();
+      const isFirstRun = fs.readdirSync(userDataDir).length === 0;
 
-      // Analysis is wrapped so a thrown phase still leaves forensics on
-      // disk. The test still fails (see expect at the end) — but the
-      // dump JSON records the error + stack, and we also attempt an
-      // HTML snapshot independently. #79.
-      let dump;
-      let dumpError = null;
+      const context = await chromium.launchPersistentContext(userDataDir, {
+        channel: 'chrome',
+        headless: false,
+        viewport: { width: 1400, height: 900 },
+        args: ['--disable-blink-features=AutomationControlled'],
+        recordVideo: { dir: testInfo.outputDir }
+      });
+
+      await context.tracing.start({
+        screenshots: true,
+        snapshots: true,
+        sources: true
+      });
+
+      const page = context.pages()[0] || await context.newPage();
+
       try {
-        dump = await dumpSite(page);
-      } catch (e) {
-        dumpError = e;
-        dump = {
-          error: e.message,
-          stack: e.stack,
-          timestamp: new Date().toISOString(),
-          site: site.id,
-          url: page.url()
-        };
-        console.error(`[${site.label}] dumpSite threw:`, e.message);
-      }
-
-      const jsonPath = path.join(OUT_DIR, `${site.id}.json`);
-      fs.writeFileSync(jsonPath, JSON.stringify(dump, null, 2));
-
-      const htmlPath = path.join(FIXTURES_DIR, `sidebar-${site.id}.html`);
-      try {
-        fs.writeFileSync(htmlPath, await page.content());
-      } catch (e) {
-        console.error(`[${site.label}] page.content() failed — page may be closed:`, e.message);
-      }
-
-      if (dumpError) {
-        console.log(`\n✗ ${site.label} — dump failed`);
-        console.log(`  Dump (error form): ${path.relative(process.cwd(), jsonPath)}`);
-        console.log(`  Fixture:           ${path.relative(process.cwd(), htmlPath)}`);
-        console.log(`  Trace:             test-results/<dir>/trace.zip (open with: npx playwright show-trace ...)`);
-      } else {
-        console.log(`\n✓ ${site.label}`);
-        console.log(`  Dump:       ${path.relative(process.cwd(), jsonPath)}`);
-        console.log(`  Fixture:    ${path.relative(process.cwd(), htmlPath)}`);
-        console.log(`  Scrollables: ${dump.scrollableContainers.length}`);
-        if (dump.mostLikelySidebar) {
-          const fps = dump.mostLikelySidebar.childClassFingerprints || {};
-          const top = Object.entries(fps).sort((a, b) => b[1] - a[1])[0];
-          console.log(`  Sidebar:    ${dump.mostLikelySidebarSelector}`);
-          console.log(`  Children:   ${dump.mostLikelySidebar.childCount}`);
-          if (top) console.log(`  Pattern:    ${top[1]}x "${top[0] || '(no classes)'}"`);
+        console.log(`\n=== ${site.label.toUpperCase()} — ${site.url} ===`);
+        console.log(`Hint: ${site.hint}`);
+        console.log(`Profile: ${userDataDir}`);
+        if (isFirstRun) {
+          console.log('First run for this site — you will need to log in.');
+        } else {
+          console.log('Profile already authenticated — verify sidebar is visible, then resume.');
         }
-        if (dump.urlScheme && dump.urlScheme.afterUrl) {
-          console.log(`  URL click:  ${dump.urlScheme.afterUrl}`);
-        } else if (dump.urlScheme && dump.urlScheme.error) {
-          console.log(`  URL click:  ERROR — ${dump.urlScheme.error}`);
-        }
-      }
+        console.log('When ready, click Resume in the Playwright Inspector.\n');
 
-      // Rethrow with the original error so Playwright surfaces a useful
-      // stack (instead of a cryptic "Cannot read properties of undefined").
-      if (dumpError) throw dumpError;
-      expect(dump.scrollableContainers.length).toBeGreaterThan(0);
+        await page.goto(site.url, { waitUntil: 'domcontentloaded' });
+        await page.pause();
+
+        let dump;
+        let dumpError = null;
+        try {
+          dump = await dumpSite(page);
+        } catch (e) {
+          dumpError = e;
+          dump = {
+            error: e.message,
+            stack: e.stack,
+            timestamp: new Date().toISOString(),
+            site: site.id,
+            url: page.url()
+          };
+          console.error(`[${site.label}] dumpSite threw:`, e.message);
+        }
+
+        const jsonPath = path.join(OUT_DIR, `${site.id}.json`);
+        fs.writeFileSync(jsonPath, JSON.stringify(dump, null, 2));
+
+        const htmlPath = path.join(FIXTURES_DIR, `sidebar-${site.id}.html`);
+        try {
+          fs.writeFileSync(htmlPath, await page.content());
+        } catch (e) {
+          console.error(`[${site.label}] page.content() failed — page may be closed:`, e.message);
+        }
+
+        if (dumpError) {
+          console.log(`\n✗ ${site.label} — dump failed`);
+          console.log(`  Dump (error form): ${path.relative(process.cwd(), jsonPath)}`);
+          console.log(`  Fixture:           ${path.relative(process.cwd(), htmlPath)}`);
+          console.log(`  Trace:             ${path.relative(process.cwd(), testInfo.outputDir)}/trace.zip`);
+        } else {
+          console.log(`\n✓ ${site.label}`);
+          console.log(`  Dump:       ${path.relative(process.cwd(), jsonPath)}`);
+          console.log(`  Fixture:    ${path.relative(process.cwd(), htmlPath)}`);
+          console.log(`  Scrollables: ${dump.scrollableContainers.length}`);
+          if (dump.mostLikelySidebar) {
+            const fps = dump.mostLikelySidebar.childClassFingerprints || {};
+            const top = Object.entries(fps).sort((a, b) => b[1] - a[1])[0];
+            console.log(`  Sidebar:    ${dump.mostLikelySidebarSelector}`);
+            console.log(`  Children:   ${dump.mostLikelySidebar.childCount}`);
+            if (top) console.log(`  Pattern:    ${top[1]}x "${top[0] || '(no classes)'}"`);
+          }
+          if (dump.urlScheme && dump.urlScheme.afterUrl) {
+            console.log(`  URL click:  ${dump.urlScheme.afterUrl}`);
+          } else if (dump.urlScheme && dump.urlScheme.error) {
+            console.log(`  URL click:  ERROR — ${dump.urlScheme.error}`);
+          }
+        }
+
+        if (dumpError) throw dumpError;
+        expect(dump.scrollableContainers.length).toBeGreaterThan(0);
+      } finally {
+        try {
+          await context.tracing.stop({ path: path.join(testInfo.outputDir, 'trace.zip') });
+        } catch (e) {
+          // Trace-stop can fail if the context already died; not fatal.
+        }
+        await context.close();
+      }
     });
   }
 });


### PR DESCRIPTION
## Summary

After first live run: Gemini succeeded, Claude died mid-navigation, user was (rightly) unwilling to log in all three sites again. Ships the ADR-0201 Option-B escalation: per-site persistent Chrome profiles at `~/.clio-profiles/{site}/`. Login is durable across runs.

## Changes

- **`tests/e2e/dom-discovery.spec.js`** — replaces default page fixture with per-test `chromium.launchPersistentContext(userDataDir, ...)`. userDataDir = `~/.clio-profiles/{site}/` — outside repo, outside test-results, survives reclones. Manual `context.tracing.start/stop` replaces fixture-managed trace; `recordVideo` option replaces fixture-managed video. Option A dodges (channel:chrome + disable-blink-features=AutomationControlled) preserved — the two options stack. All #79 instrumentation preserved (phase logging, defensive dump, error-form dump).
- **`docs/adrs/0201-playwright-system-chrome-channel.md`** — top-of-doc status note ("Option A + Option B, both implemented same day"), Section 7 rewritten with the dual-option pattern and further escalation paths.
- **`docs/runbooks/30001-development-runbook.md`** — new "Persistent login profiles" subsection: first-run vs subsequent-run expectation, profile location, force-re-login commands.

## User-facing behavior

- **First run of this PR** — log in to each of the three sites one more time. Those logins get cached to `~/.clio-profiles/`.
- **Every subsequent run** — Chrome lands on the logged-in conversation list. No sign-in. Total runtime ~1-2 min instead of ~5-10 min.
- **Expected next run:** three logins, then Gemini / Claude / ChatGPT dumps should all complete.

## Test plan

- [x] `npx playwright test --list` enumerates 3 tests
- [x] Spec parses cleanly with `launchPersistentContext` + manual tracing
- [x] ADR reflects current dual-implementation state
- [x] Runbook communicates the first-run-vs-subsequent distinction
- [ ] End-to-end live run: logins persist, all three dumps written, trace/video captured

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)