### PR TITLE
chore: add LICENSE (MIT), CONTRIBUTING, issue/PR templates (Closes #87)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Something in Clio is not working the way it should
+title: ''
+labels: bug
+assignees: ''
+---
+
+## What happened
+
+<!-- One-paragraph description of the unexpected behavior. -->
+
+## What you expected to happen
+
+<!-- One-paragraph description of what should have happened. -->
+
+## Reproduction
+
+1.
+2.
+3.
+
+## Environment
+
+- Clio version: <!-- e.g. 1.3.3 (check chrome://extensions) -->
+- Browser: <!-- Chrome / Edge / Brave + version -->
+- Site affected: <!-- gemini.google.com / claude.ai / chatgpt.com -->
+- OS: <!-- Windows / macOS / Linux -->
+
+## Output artifacts
+
+<!-- If extraction completed but produced wrong data, attach a redacted snippet
+     of conversation.json or describe the discrepancy. If extraction failed,
+     paste any error message from the popup. -->
+
+## Console errors
+
+<!-- Open DevTools on the conversation tab (F12 → Console) and paste any
+     Clio-related errors here. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/martymcenroe/Clio/blob/main/SECURITY.md
+    about: Please report security vulnerabilities privately — see SECURITY.md, do not file a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: Feature request
+about: Suggest an enhancement or new capability for Clio
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+<!-- What problem are you trying to solve? "I want X" is fine — but
+     "today I cannot do Y, which costs me Z" is much more useful. -->
+
+## Proposed solution
+
+<!-- How would you like Clio to behave? Be concrete. If you have an idea
+     about implementation, describe it; if not, that is OK. -->
+
+## Alternatives considered
+
+<!-- What other approaches did you consider? Why did you discard them? -->
+
+## Design principles to respect
+
+Clio is privacy-first and strictly local. Proposals that require sending
+conversation content to a remote server, that introduce new permissions
+without strong justification, or that conflict with the design principles in
+[CONTRIBUTING.md](../../CONTRIBUTING.md) will need extra discussion.
+
+## Additional context
+
+<!-- Screenshots, links to related issues, references — whatever helps. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!--
+Every PR must:
+- Reference an open issue with `Closes #N` in this body (not just the title).
+- Pass tests (`npm test`) and produce no new lint warnings.
+- Stay scoped to one issue. Split unrelated changes into separate PRs.
+-->
+
+## Summary
+
+<!-- 1-3 bullets describing what changed and why. -->
+
+## Test plan
+
+<!-- Checklist of what you ran or verified. Examples:
+- [ ] `npm test` passes
+- [ ] Loaded extension, extracted a Gemini conversation, JSON looks correct
+- [ ] No new console errors in the popup or page
+-->
+
+## Closes
+
+Closes #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing to Clio
+
+Thanks for your interest in Clio. Clio is a Chrome extension that extracts full Gemini, Claude, and ChatGPT conversations to structured JSON. All processing happens locally — privacy is a core design constraint, not a feature.
+
+## Development setup
+
+```bash
+git clone https://github.com/martymcenroe/Clio.git
+cd Clio
+npm install
+```
+
+### Loading the extension in Chrome
+
+1. Open `chrome://extensions` (or `edge://extensions`)
+2. Enable **Developer mode** (top right)
+3. Click **Load unpacked**
+4. Select the `extensions/` folder
+
+When you change extension source, click the reload button on the Clio card in `chrome://extensions`, then refresh the conversation tab.
+
+## Running tests
+
+```bash
+npm test                 # Jest unit tests
+npm run test:coverage    # With coverage report
+npm run test:e2e         # Playwright end-to-end tests
+npm run test:all         # Everything
+```
+
+All PRs must pass `npm test` cleanly. See `docs/runbooks/30001-development-runbook.md` for the full development guide.
+
+## Pull requests
+
+- **One issue per PR.** Every PR must reference an open issue with `Closes #N` in the PR body. The naked `(#N)` format is not allowed.
+- **Atomic commits.** Each commit should be a coherent unit. Squash before merge.
+- **Tests stay real.** Do not mock to make tests pass. If a test is hard to write, that is a design signal.
+- **No comments on the obvious.** Lead with well-named identifiers. Comment only when *why* is non-obvious.
+
+## Issues
+
+Please use the provided issue templates (bug report / feature request). If you've found a security vulnerability, do *not* file a public issue — see [SECURITY.md](SECURITY.md) for the private reporting channel.
+
+## Design principles
+
+These are load-bearing — please respect them in any change you propose:
+
+- **Fail open for images.** Image-fetch errors are logged but do not fail the extraction. Text is the primary artifact.
+- **Fail closed for text.** If no messages are found, extraction fails loudly — silent partial captures would corrupt the user's archive.
+- **Local processing only.** Clio does not send conversation content to any external server. Permissions, host_permissions, and code paths are scoped to enforce this.
+- **Minimal manifest surface.** Adding a permission requires an explicit justification in the PR.
+
+## Release process
+
+See `docs/runbooks/30002-chrome-web-store-publish.md` (when present) for the Chrome Web Store submission process. Versioning follows semver as expressed in `extensions/manifest.json`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,135 +1,21 @@
-# PolyForm Noncommercial License 1.0.0
+MIT License
 
-<https://polyformproject.org/licenses/noncommercial/1.0.0>
+Copyright (c) 2026 Martin McEnroe / THRIVETECH.AI
 
-## Acceptance
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-In order to get any license under these terms, you must agree
-to them as both strict obligations and conditions to all
-your licenses.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-## Copyright License
-
-The licensor grants you a copyright license for the
-software to do everything you might do with the software
-that would otherwise infringe the licensor's copyright
-in it for any permitted purpose.  However, you may
-only distribute the software according to [Distribution
-License](#distribution-license) and make changes or new works
-based on the software according to [Changes and New Works
-License](#changes-and-new-works-license).
-
-## Distribution License
-
-The licensor grants you an additional copyright license
-to distribute copies of the software.  Your license
-to distribute covers distributing the software with
-changes and new works permitted by [Changes and New Works
-License](#changes-and-new-works-license).
-
-## Notices
-
-You must ensure that anyone who gets a copy of any part of
-the software from you also gets a copy of these terms or the
-URL for them above, as well as copies of any plain-text lines
-beginning with `Required Notice:` that the licensor provided
-with the software.  For example:
-
-> Required Notice: Copyright Marty McEnroe (https://github.com/martymcenroe)
-
-## Changes and New Works License
-
-The licensor grants you an additional copyright license to
-make changes and new works based on the software for any
-permitted purpose.
-
-## Patent License
-
-The licensor grants you a patent license for the software that
-covers patent claims the licensor can license, or becomes able
-to license, that you would infringe by using the software.
-
-## Noncommercial Purposes
-
-Any noncommercial purpose is a permitted purpose.
-
-## Personal Uses
-
-Personal use for research, experiment, and testing for
-the benefit of public knowledge, personal study, private
-entertainment, hobby projects, amateur pursuits, or religious
-observance, without any anticipated commercial application,
-is use for a permitted purpose.
-
-## Noncommercial Organizations
-
-Use by any charitable organization, educational institution,
-public research organization, public safety or health
-organization, environmental protection organization,
-or government institution is use for a permitted purpose
-regardless of the source of funding or obligations resulting
-from the funding.
-
-## Fair Use
-
-You may have "fair use" rights for the software under the
-law. These terms do not limit them.
-
-## No Other Rights
-
-These terms do not allow you to sublicense or transfer any of
-your licenses to anyone else, or prevent the licensor from
-granting licenses to anyone else.  These terms do not imply
-any other licenses.
-
-## Patent Defense
-
-If you make any written claim that the software infringes or
-contributes to infringement of any patent, your patent license
-for the software granted under these terms ends immediately. If
-your company makes such a claim, your patent license ends
-immediately for work on behalf of your company.
-
-## Violations
-
-The first time you are notified in writing that you have
-violated any of these terms, or done anything with the software
-not covered by your licenses, your licenses can nonetheless
-continue if you come into full compliance with these terms,
-and take practical steps to correct past violations, within
-32 days of receiving notice.  Otherwise, all your licenses
-end immediately.
-
-## No Liability
-
-***As far as the law allows, the software comes as is, without
-any warranty or condition, and the licensor will not be liable
-to you for any damages arising out of these terms or the use
-or nature of the software, under any kind of legal claim.***
-
-## Definitions
-
-The **licensor** is the individual or entity offering these
-terms, and the **software** is the software the licensor makes
-available under these terms.
-
-**You** refers to the individual or entity agreeing to these
-terms.
-
-**Your company** is any legal entity, sole proprietorship,
-or other kind of organization that you work for, plus all
-organizations that have control over, are under the control of,
-or are under common control with that organization.  **Control**
-means ownership of substantially all the assets of an entity,
-or the power to direct its management and policies by vote,
-contract, or otherwise.  Control can be direct or indirect.
-
-**Your licenses** are all the licenses granted to you for the
-software under these terms.
-
-**Use** means anything you do with the software requiring one
-of your licenses.
-
----
-
-Required Notice: Copyright (c) 2026 Marty McEnroe (https://github.com/martymcenroe)
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md` (dev setup, test workflow, PR conventions, design principles)
- Add `LICENSE` (MIT) — **replaces** previous PolyForm Noncommercial 1.0.0 per project direction
- Add `.github/ISSUE_TEMPLATE/bug_report.md`, `feature_request.md`, `config.yml`
- Add `.github/PULL_REQUEST_TEMPLATE.md` with `Closes #N` checklist
- `config.yml` disables blank issues and routes security reports to `SECURITY.md` (will exist after #85 lands)

## License change — please confirm

The repo previously had **PolyForm Noncommercial 1.0.0**. The README claimed MIT. When asked which to keep, you chose MIT, so this PR replaces the LICENSE file with standard MIT (copyright Martin McEnroe / THRIVETECH.AI, year 2026).

If you want PolyForm back, revert before merging — this is a re-licensing decision worth a second look.

## Test plan

- [x] No code changes; existing test suite unaffected
- [ ] Verify GitHub repo header shows "MIT" instead of "Other" after merge
- [ ] Verify new-issue dialog shows the templates
- [ ] Verify new-PR dialog pre-fills the template

## Closes

Closes #87