### PR TITLE
docs: add privacy policy (PRIVACY.md + docs/privacy.html) (Closes #84)

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,78 @@
+# Privacy Policy
+
+**Last updated:** 2026-05-22
+
+## Summary
+
+Clio is a Chrome extension that extracts your Gemini, Claude, and ChatGPT conversations to local JSON files. **All processing happens in your browser.** Clio does not transmit your conversations to any external server, does not send telemetry, and does not collect personally identifiable information.
+
+This policy describes precisely what Clio does and does not do with data.
+
+## What Clio processes
+
+When you press the toolbar button on a supported LLM site, Clio reads the **conversation DOM** of the page you are currently viewing. That includes:
+
+- The text of your messages and the assistant's replies
+- Code blocks, with language labels preserved
+- Images embedded in the conversation (when present)
+- Assistant "thinking" / reasoning sections, when expanded
+- The conversation title, conversation ID, and URL
+
+These pieces are assembled into a ZIP archive containing:
+
+- `conversation.json` — the structured transcript
+- `images/` — extracted image files
+
+## Where this data goes
+
+The ZIP file is written to your local disk via Chrome's `chrome.downloads` API. The "Save As" dialog from Chrome lets you pick the destination. **That is the only place the data goes.**
+
+Clio does not:
+
+- Transmit conversation content to any external server
+- Send telemetry, error reports, or usage analytics
+- Maintain a remote database
+- Share data with third parties
+- Track you across sites
+- Embed any analytics, advertising, or fingerprinting library
+- Load any code from a remote source (everything is bundled in the extension)
+
+You can verify this by reading the [extension manifest](extensions/manifest.json) and the source code — there are no `fetch` or `XMLHttpRequest` calls to any origin outside `gemini.google.com`, `claude.ai`, and `chatgpt.com`, and those exist only to read the DOM rendered for you in your own session.
+
+## Permission rationale
+
+The Chrome Web Store requires extensions to justify every permission they request. Clio's manifest is intentionally minimal:
+
+| Permission | What it allows | Why Clio needs it |
+|-----------|----------------|-------------------|
+| `activeTab` | Read the DOM of the tab you are currently looking at, only when you press the toolbar button | Required to read the conversation you want to extract |
+| `downloads` | Write the result ZIP via the "Save As" dialog | Required to save the extraction to your disk |
+| `host_permissions` for `gemini.google.com`, `claude.ai`, `chatgpt.com` | Inject Clio's DOM-walking content script on those exact sites | The three sites Clio supports — nowhere else |
+
+Permissions Clio does **not** request: `tabs`, `cookies`, `webRequest`, `storage`, `identity`, `notifications`, broader `host_permissions`.
+
+## Open-source transparency
+
+Clio's full source code is available at [github.com/martymcenroe/Clio](https://github.com/martymcenroe/Clio). The extension is licensed under [MIT](LICENSE). You can build the same extension from source and verify byte-for-byte what is running.
+
+The security posture is documented in detail in [SECURITY.md](SECURITY.md), including the threat model and explicit out-of-scope items.
+
+## Your control over your data
+
+Because all data lives only on your local disk, your data subject rights are exercised by you directly through your operating system: delete the ZIP files when you no longer want them. Clio has no remote copy of anything to delete on your behalf.
+
+The conversations themselves remain on the LLM provider's servers under their own privacy terms — Clio does not change anything about Google's, Anthropic's, or OpenAI's data handling. Clio gives you a local copy; it does not remove the original.
+
+## Children's privacy
+
+Clio does not knowingly collect any data from anyone, including children. If you believe a child has been harmed by Clio's behavior, please contact us at the email below — but note that Clio runs locally and does not store or transmit data.
+
+## Changes to this policy
+
+If this policy changes materially, the change will be reflected in a new "Last updated" date and announced in the project's [CHANGELOG.md](CHANGELOG.md).
+
+## Contact
+
+Privacy questions: **martymcenroe@gmail.com** (subject: `Clio privacy question`)
+
+Security vulnerabilities should be reported per [SECURITY.md](SECURITY.md), not as privacy questions.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the full release history.
 
 ## Privacy
 
-All data processing happens locally in your browser. No data is sent to any external servers.
+All data processing happens locally in your browser. No data is sent to any external servers. See [PRIVACY.md](PRIVACY.md) for the full policy, and [SECURITY.md](SECURITY.md) for the threat model and vulnerability-reporting channel.
 
 ## License
 

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy — Clio</title>
+  <meta name="description" content="Privacy policy for Clio, a Chrome extension that extracts Gemini, Claude, and ChatGPT conversations to local JSON. All processing is local.">
+  <link rel="canonical" href="https://martymcenroe.github.io/Clio/privacy.html">
+
+  <style>
+    :root {
+      --text: #1a1a1a;
+      --muted: #555;
+      --rule: #e5e5e5;
+      --accent: #1a5490;
+      --bg: #fafafa;
+      --card: #ffffff;
+      --code-bg: #f0f0f0;
+    }
+    * { box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+      color: var(--text);
+      background: var(--bg);
+      line-height: 1.65;
+      margin: 0;
+      padding: 0;
+    }
+    .container {
+      max-width: 760px;
+      margin: 0 auto;
+      padding: 48px 24px 96px;
+    }
+    header {
+      border-bottom: 1px solid var(--rule);
+      margin-bottom: 32px;
+      padding-bottom: 16px;
+    }
+    header h1 {
+      margin: 0 0 8px;
+      font-size: 2rem;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+    .last-updated {
+      color: var(--muted);
+      font-size: 0.9rem;
+      margin: 0;
+    }
+    h2 {
+      margin-top: 48px;
+      margin-bottom: 16px;
+      font-size: 1.5rem;
+      font-weight: 700;
+      letter-spacing: -0.01em;
+      color: var(--text);
+    }
+    h3 {
+      margin-top: 32px;
+      margin-bottom: 12px;
+      font-size: 1.1rem;
+      font-weight: 600;
+    }
+    p, li { font-size: 1rem; }
+    .summary {
+      background: var(--card);
+      border-left: 4px solid var(--accent);
+      padding: 20px 24px;
+      margin: 24px 0;
+      border-radius: 4px;
+    }
+    .summary strong { color: var(--accent); }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 16px 0;
+      font-size: 0.95rem;
+    }
+    th, td {
+      text-align: left;
+      padding: 10px 12px;
+      border-bottom: 1px solid var(--rule);
+      vertical-align: top;
+    }
+    th {
+      background: var(--card);
+      font-weight: 600;
+    }
+    code {
+      background: var(--code-bg);
+      padding: 2px 6px;
+      border-radius: 3px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 0.92em;
+    }
+    a { color: var(--accent); }
+    a:hover { text-decoration: underline; }
+    ul { padding-left: 24px; }
+    li { margin-bottom: 6px; }
+    footer {
+      margin-top: 64px;
+      padding-top: 24px;
+      border-top: 1px solid var(--rule);
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+    footer a { color: var(--muted); }
+  </style>
+</head>
+<body>
+<div class="container">
+
+<header>
+  <h1>Privacy Policy</h1>
+  <p class="last-updated">Last updated: 2026-05-22</p>
+</header>
+
+<div class="summary">
+  <strong>Summary:</strong> Clio is a Chrome extension that extracts your Gemini, Claude, and ChatGPT conversations to local JSON files. All processing happens in your browser. Clio does not transmit your conversations to any external server, does not send telemetry, and does not collect personally identifiable information.
+</div>
+
+<h2>What Clio processes</h2>
+
+<p>When you press the toolbar button on a supported LLM site, Clio reads the <strong>conversation DOM</strong> of the page you are currently viewing. That includes:</p>
+
+<ul>
+  <li>The text of your messages and the assistant's replies</li>
+  <li>Code blocks, with language labels preserved</li>
+  <li>Images embedded in the conversation (when present)</li>
+  <li>Assistant "thinking" / reasoning sections, when expanded</li>
+  <li>The conversation title, conversation ID, and URL</li>
+</ul>
+
+<p>These pieces are assembled into a ZIP archive containing <code>conversation.json</code> (the structured transcript) and an <code>images/</code> folder with extracted image files.</p>
+
+<h2>Where this data goes</h2>
+
+<p>The ZIP file is written to your local disk via Chrome's <code>chrome.downloads</code> API. The "Save As" dialog from Chrome lets you pick the destination. <strong>That is the only place the data goes.</strong></p>
+
+<p>Clio does <strong>not</strong>:</p>
+
+<ul>
+  <li>Transmit conversation content to any external server</li>
+  <li>Send telemetry, error reports, or usage analytics</li>
+  <li>Maintain a remote database</li>
+  <li>Share data with third parties</li>
+  <li>Track you across sites</li>
+  <li>Embed any analytics, advertising, or fingerprinting library</li>
+  <li>Load any code from a remote source (everything is bundled in the extension)</li>
+</ul>
+
+<p>You can verify this by reading the <a href="https://github.com/martymcenroe/Clio/blob/main/extensions/manifest.json">extension manifest</a> and the source code — there are no <code>fetch</code> or <code>XMLHttpRequest</code> calls to any origin outside <code>gemini.google.com</code>, <code>claude.ai</code>, and <code>chatgpt.com</code>, and those exist only to read the DOM rendered for you in your own session.</p>
+
+<h2>Permission rationale</h2>
+
+<p>The Chrome Web Store requires extensions to justify every permission they request. Clio's manifest is intentionally minimal:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Permission</th>
+      <th>What it allows</th>
+      <th>Why Clio needs it</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>activeTab</code></td>
+      <td>Read the DOM of the tab you are currently looking at, only when you press the toolbar button</td>
+      <td>Required to read the conversation you want to extract</td>
+    </tr>
+    <tr>
+      <td><code>downloads</code></td>
+      <td>Write the result ZIP via the "Save As" dialog</td>
+      <td>Required to save the extraction to your disk</td>
+    </tr>
+    <tr>
+      <td><code>host_permissions</code> for <code>gemini.google.com</code>, <code>claude.ai</code>, <code>chatgpt.com</code></td>
+      <td>Inject Clio's DOM-walking content script on those exact sites</td>
+      <td>The three sites Clio supports — nowhere else</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Permissions Clio does <strong>not</strong> request: <code>tabs</code>, <code>cookies</code>, <code>webRequest</code>, <code>storage</code>, <code>identity</code>, <code>notifications</code>, broader <code>host_permissions</code>.</p>
+
+<h2>Open-source transparency</h2>
+
+<p>Clio's full source code is available at <a href="https://github.com/martymcenroe/Clio">github.com/martymcenroe/Clio</a>. The extension is licensed under <a href="https://github.com/martymcenroe/Clio/blob/main/LICENSE">MIT</a>. You can build the same extension from source and verify byte-for-byte what is running.</p>
+
+<p>The security posture is documented in detail in <a href="https://github.com/martymcenroe/Clio/blob/main/SECURITY.md">SECURITY.md</a>, including the threat model and explicit out-of-scope items.</p>
+
+<h2>Your control over your data</h2>
+
+<p>Because all data lives only on your local disk, your data subject rights are exercised by you directly through your operating system: delete the ZIP files when you no longer want them. Clio has no remote copy of anything to delete on your behalf.</p>
+
+<p>The conversations themselves remain on the LLM provider's servers under their own privacy terms — Clio does not change anything about Google's, Anthropic's, or OpenAI's data handling. Clio gives you a local copy; it does not remove the original.</p>
+
+<h2>Children's privacy</h2>
+
+<p>Clio does not knowingly collect any data from anyone, including children. If you believe a child has been harmed by Clio's behavior, please contact us at the email below — but note that Clio runs locally and does not store or transmit data.</p>
+
+<h2>Changes to this policy</h2>
+
+<p>If this policy changes materially, the change will be reflected in a new "Last updated" date and announced in the project's <a href="https://github.com/martymcenroe/Clio/blob/main/CHANGELOG.md">CHANGELOG.md</a>.</p>
+
+<h2>Contact</h2>
+
+<p>Privacy questions: <strong>martymcenroe@gmail.com</strong> (subject: <code>Clio privacy question</code>)</p>
+
+<p>Security vulnerabilities should be reported per <a href="https://github.com/martymcenroe/Clio/blob/main/SECURITY.md">SECURITY.md</a>, not as privacy questions.</p>
+
+<footer>
+  <p><a href="https://github.com/martymcenroe/Clio">Clio on GitHub</a> · MIT License · Copyright © 2026 Martin McEnroe / THRIVETECH.AI</p>
+</footer>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- `PRIVACY.md` at repo root — strict-local privacy story for GitHub readers
- `docs/privacy.html` — same content, styled for GitHub Pages hosting (URL Chrome Web Store requires in the listing's Privacy Policy field)
- README's Privacy section now links to both PRIVACY.md and SECURITY.md

## Substance

The policy is short and factual:
- What Clio processes (DOM you're already viewing)
- Where it goes (your local disk via chrome.downloads — nowhere else)
- What is NOT done (no remote, no telemetry, no third parties, no fingerprinting, no remote code)
- Permission rationale table (activeTab, downloads, the 3 host_permissions)
- How users exercise data control (delete the files; Clio has nothing remote to forget)

## What this unblocks

CWS dashboard requires a Privacy Policy URL for any extension that handles "user data" (which by their definition we do, since we read conversation text). Once #88 stands up the Pages site, the URL will be:

> https://martymcenroe.github.io/Clio/privacy.html

That URL goes in the dashboard's Privacy tab.

## Test plan

- [x] No code changes; existing tests unaffected
- [ ] After merge: render `docs/privacy.html` locally — verify links resolve once Pages is live (#88)
- [ ] Verify table renders, summary callout displays
- [ ] Read top-to-bottom and confirm wording is comfortable for a CWS reviewer

## Closes

Closes #84