### PR TITLE
chore: set .unleashed.json assemblyZero=true (Refs AssemblyZero#1212)

### DIFF
--- a/.unleashed.json
+++ b/.unleashed.json
@@ -3,7 +3,7 @@
   "claude": {
     "effort": "max"
   },
-  "assemblyZero": false,
+  "assemblyZero": true,
   "onboard": {
     "auto": true,
     "pickupThresholdMinutes": 10,


### PR DESCRIPTION
## Summary

One-line config change: set `.unleashed.json` `assemblyZero` field to `true`.

## Why

AssemblyZero #1212 fleet backfill. `tools/new_repo_setup.py` in AssemblyZero defaults `.unleashed.json` to `assemblyZero: true` since #1059. Existing repos that predate that change have the field missing or `false`, which means `/onboard` skips loading AssemblyZero's CLAUDE.md / gemini rotation instructions for sessions in this repo. Setting the flag aligns this repo with the fleet default.

## Test plan

- [x] One-line config edit
- [x] No code changes; no tests affected
- [ ] After merge, next `/onboard` in this repo loads AZ rules

Refs AssemblyZero#1212

No-Issue: AssemblyZero fleet backfill — tracking issue is AssemblyZero#1212 (cross-repo; no per-repo issue needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
