### PR TITLE
docs(runbook): 30003 deploys from dist/site/ not docs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ Thumbs.db
 
 # Build artifacts
 *.zip
+dist/
 
 # Temporary files
 tmp/
@@ -33,3 +34,6 @@ docs/session-logs/
 
 # Unleashed session transcripts (auto-generated, untracked)
 data/unleashed/
+
+# Handoff logs
+data/handoff-log.md

--- a/docs/runbooks/30003-cloudflare-pages-setup.md
+++ b/docs/runbooks/30003-cloudflare-pages-setup.md
@@ -8,6 +8,14 @@ This is a one-time setup. After the initial wiring, every push to `main` trigger
 
 ---
 
+## Critical rule: never deploy from `docs/`
+
+`docs/` is a mixed-content directory holding 3 public files (`index.html`, `privacy.html`, `_redirects`) alongside ~24 internal artifacts (LLDs, runbooks, ADRs, reports). On 2026-05-23 a first deploy via `wrangler pages deploy docs` uploaded all 31 files to a public CFP project — the project was deleted within minutes and triggered a fleet-wide session-log audit across 21 repos.
+
+**Fleet rule (post-incident):** always deploy from `dist/site/`, which is produced by `python tools/build_site.py`. The script copies exactly the 3 public files and wipes anything else first, so a future renamed/removed file does not linger. Path A wires this as the CFP build command; Path B runs it before every `wrangler pages deploy`.
+
+---
+
 ## Prerequisites
 
 - [ ] `wrangler` CLI installed and authenticated against the publisher's Cloudflare account (`mcwizard1@gmail.com`, the same account `aletheia-api` runs in). Verify: `wrangler whoami` shows the right email.
@@ -79,10 +87,12 @@ If prompted, authorize the Cloudflare GitHub App. Grant access to the `martymcen
 | Repository | `martymcenroe/Clio` |
 | Project name | `clio` (this becomes `clio.pages.dev` as the default subdomain) |
 | Production branch | `main` |
-| Build command | *(leave blank)* — the site is pure static HTML, no build step |
-| Build output directory | `docs` |
+| Build command | `python tools/build_site.py` — copies the 3 public files into `dist/site/` |
+| Build output directory | `dist/site` |
 | Root directory | *(leave blank)* — defaults to repo root |
 | Environment variables | *(none needed)* |
+
+> **Do NOT set Build output directory to `docs`.** See "Critical rule" above — that's the configuration that caused the 2026-05-23 incident.
 
 Click **Save and Deploy**.
 
@@ -170,12 +180,13 @@ Use this path only if you've decided against the GitHub integration. Each deploy
 
 ```bash
 cd /c/Users/mcwiz/Projects/Clio
-wrangler whoami                                  # verify Cloudflare identity
-wrangler pages project create clio               # creates the project
-wrangler pages deploy docs --project-name=clio   # first deploy
+wrangler whoami                                       # verify Cloudflare identity
+wrangler pages project create clio --production-branch=main   # creates the project
+python tools/build_site.py                            # build dist/site/ from docs/
+wrangler pages deploy dist/site --project-name=clio   # first deploy (3 files)
 ```
 
-The output reports the `clio.pages.dev` URL.
+The output reports the `clio.pages.dev` URL. `wrangler` will print "Uploading 3 files" — if it says more than 3, abort and check that you ran `tools/build_site.py` and pointed `--project-name` at `dist/site`, not `docs`.
 
 ### Bind the custom domain
 
@@ -183,15 +194,16 @@ Same as Path A Step 5 — through the dashboard. Wrangler doesn't (yet) have a s
 
 ### Deploy on every update
 
-After merging a PR that touches `docs/`:
+After merging a PR that touches `docs/index.html`, `docs/privacy.html`, or `docs/_redirects`:
 
 ```bash
 cd /c/Users/mcwiz/Projects/Clio
 git pull
-wrangler pages deploy docs --project-name=clio
+python tools/build_site.py
+wrangler pages deploy dist/site --project-name=clio
 ```
 
-Each invocation creates a new deployment in the project history; the latest replaces the live site within seconds.
+Each invocation creates a new deployment in the project history; the latest replaces the live site within seconds. The build script is idempotent — re-running on an unchanged source produces an identical `dist/site/`.
 
 ### Update the GitHub repo metadata
 
@@ -211,11 +223,16 @@ CF Pages dashboard → **Deployments** → find the previous green deploy → **
 
 ### Adding pages
 
-Drop any `.html` file under `docs/` and it will be reachable at `https://cliocast.com/<filename>`. Add a corresponding `_redirects` rule if you want a clean URL.
+1. Drop the new `.html` file under `docs/`.
+2. Add its filename to the `SITE_FILES` list at the top of `tools/build_site.py`.
+3. Add a corresponding `_redirects` rule if you want a clean URL.
+4. Merge to `main` — Path A auto-deploys; Path B requires you to run `python tools/build_site.py && wrangler pages deploy dist/site --project-name=clio`.
+
+The `SITE_FILES` step is load-bearing: any file not in that list is **excluded** from the build output. This is the safety net that prevents internal docs from accidentally shipping.
 
 ### Adding redirects
 
-Edit `docs/_redirects`. Cloudflare Pages re-reads on every deploy. The syntax is `source destination status` per line; status `200` is a rewrite (URL stays clean), `301`/`302` is a redirect (URL changes in the address bar).
+Edit `docs/_redirects`. Cloudflare Pages re-reads on every deploy. The syntax is `source destination status` per line; status `200` is a rewrite (URL stays clean), `301`/`302` is a redirect (URL changes in the address bar). `_redirects` is already in `SITE_FILES`, so no change to `tools/build_site.py` is needed.
 
 ---
 
@@ -235,6 +252,7 @@ Edit `docs/_redirects`. Cloudflare Pages re-reads on every deploy. The syntax is
 ## Related documents
 
 - `docs/runbooks/30002-chrome-web-store-publish.md` — the Chrome Web Store submission runbook; uses the URL stood up here
+- `tools/build_site.py` — the build script Path A and Path B both invoke; canonical list of public-facing files
 - `PRIVACY.md` and `docs/privacy.html` — the content this runbook publishes
 - `AssemblyZero/docs/adrs/0216-in-process-classic-pat-decryption.md` — the classic-PAT pattern
 - `AssemblyZero/tools/update_clio_repo_metadata.py` — the script Step 7 invokes

--- a/tools/build_site.py
+++ b/tools/build_site.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Build dist/site/ from docs/ for Cloudflare Pages deploy.
+
+Usage:
+    python tools/build_site.py
+
+Output:
+    dist/site/ containing only the public-facing files (index.html,
+    privacy.html, _redirects).
+
+Why this script exists
+----------------------
+`docs/` is a mixed-content directory: it holds both the 3 public-facing
+files served at cliocast.com AND ~24 internal artifacts (LLDs, runbooks,
+ADRs, reports). Deploying from `docs/` directly (as the original runbook
+30003 instructed) published all 31 files to Cloudflare Pages on
+2026-05-23 — the project was deleted within minutes and triggered a
+fleet-wide session-log audit.
+
+Fleet rule (post-incident): never deploy from a mixed-content directory.
+Always copy intended files to `dist/site/` via this script, then deploy
+`dist/site/`.
+
+The script is idempotent: it wipes `dist/site/` before each copy so a
+file removed from the source list does not linger in a future deploy.
+"""
+
+from pathlib import Path
+import shutil
+import sys
+
+REPO_ROOT = Path(__file__).parent.parent
+SOURCE_DIR = REPO_ROOT / "docs"
+DEST_DIR = REPO_ROOT / "dist" / "site"
+
+SITE_FILES = [
+    "index.html",
+    "privacy.html",
+    "_redirects",
+]
+
+
+def clean_dest(dest: Path) -> None:
+    """Remove all files in the destination so removed source files don't linger."""
+    if dest.exists():
+        for entry in dest.iterdir():
+            if entry.is_file():
+                entry.unlink()
+            elif entry.is_dir():
+                shutil.rmtree(entry)
+    else:
+        dest.mkdir(parents=True)
+
+
+def copy_files(source: Path, dest: Path, files: list[str]) -> int:
+    """Copy each file from source to dest. Returns the count copied."""
+    copied = 0
+    for name in files:
+        src = source / name
+        if not src.exists():
+            raise FileNotFoundError(f"Missing source file: {src}")
+        shutil.copy2(src, dest / name)
+        copied += 1
+    return copied
+
+
+def main() -> int:
+    print("=" * 50)
+    print("Building dist/site/ from docs/")
+    print("=" * 50)
+    print()
+
+    try:
+        print(f"Step 1: Cleaning {DEST_DIR}...")
+        clean_dest(DEST_DIR)
+        print(f"  [OK] {DEST_DIR} ready")
+
+        print(f"\nStep 2: Copying {len(SITE_FILES)} files...")
+        count = copy_files(SOURCE_DIR, DEST_DIR, SITE_FILES)
+        for name in SITE_FILES:
+            print(f"  [OK] {name}")
+
+        print()
+        print("=" * 50)
+        print("Build complete!")
+        print("=" * 50)
+        print(f"  Output: {DEST_DIR} ({count} files)")
+        print()
+        print("Deploy:")
+        print("  wrangler pages deploy dist/site --project-name=clio")
+        return 0
+
+    except FileNotFoundError as e:
+        print(f"\nERROR: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- The original runbook (PR #108) told you to `wrangler pages deploy docs` — which is the exact command that published all 31 files in `docs/` (LLDs, internal runbooks, reports, this runbook) to a public CFP project on 2026-05-23, triggering the fleet-wide session-log audit
- Adds `tools/build_site.py` — copies the 3 public files into `dist/site/`, wipes the dest first so removed sources don't linger, idempotent
- Rewrites runbook 30003 to use `dist/site/` everywhere: Path A's build command + output directory, Path B's setup + update commands, a new "Critical rule" warning section at the top citing the 2026-05-23 incident, updated "Adding pages" instructions, and an entry in Related documents
- `.gitignore` adds `dist/` so build artifacts stay out of git (mirrors `*.zip` already gitignored for `build_release.py` output)

## Test plan

- [x] `python tools/build_site.py` runs cleanly; produces `dist/site/` with exactly 3 files
- [x] Re-running the script after a manual `rm -rf dist/site` recreates it identically (idempotent)
- [x] Runbook's `Build command` / `Build output directory` table values match what `wrangler pages deploy dist/site --project-name=clio` actually consumes
- [ ] First real `wrangler pages deploy dist/site --project-name=clio` reports "Uploading 3 files" (will verify post-merge when deploying to `cliocast.com`)

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)