### PR TITLE
fix(chatgpt): modernize selectors for current ChatGPT DOM (#116)

### DIFF
--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Clio",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Extract full Gemini, Claude, and ChatGPT conversations to JSON with images",
   "permissions": [
     "activeTab",

--- a/extensions/src/content.js
+++ b/extensions/src/content.js
@@ -264,7 +264,7 @@ function countMessages() {
     return userMsgs.length + assistantMsgs.length;
   }
   if (site === 'chatgpt') {
-    return document.querySelectorAll('article[data-turn="user"], article[data-turn="assistant"]').length;
+    return document.querySelectorAll('[data-message-author-role="user"], [data-message-author-role="assistant"]').length;
   }
   // Gemini: Count ONLY primary elements (user-query, model-response)
   // Don't use composite SELECTORS which include fallbacks that may be nested
@@ -812,13 +812,13 @@ async function extractTurnsClaude() {
  * @param {number} index - Turn index
  * @returns {Object} - Turn object
  */
-function extractAssistantTurnChatGPT(article, index) {
-  const images = findImages(article, index);
+function extractAssistantTurnChatGPT(messageEl, index) {
+  const images = findImages(messageEl, index);
 
   // Extract reasoning label if present (e.g. "Reasoned about X for Y seconds")
   let thinking = null;
   if (SELECTORS.reasoningLabel) {
-    const reasoningEl = article.querySelector(SELECTORS.reasoningLabel);
+    const reasoningEl = messageEl.querySelector(SELECTORS.reasoningLabel);
     if (reasoningEl) {
       const reasonText = reasoningEl.textContent.trim();
       if (reasonText.toLowerCase().includes('reason') || reasonText.toLowerCase().includes('thought')) {
@@ -829,14 +829,16 @@ function extractAssistantTurnChatGPT(article, index) {
 
   // Extract response content from .markdown container
   const contentSelector = SELECTORS.assistantContent || '.markdown';
-  const contentEl = article.querySelector(contentSelector);
-  const content = contentEl ? extractTextContent(contentEl) : extractTextContent(article);
+  const contentEl = messageEl.querySelector(contentSelector);
+  const content = contentEl ? extractTextContent(contentEl) : extractTextContent(messageEl);
 
-  // Extract model slug if available
-  let modelSlug = null;
-  const modelEl = article.querySelector('[data-message-model-slug]');
-  if (modelEl) {
-    modelSlug = modelEl.getAttribute('data-message-model-slug');
+  // Extract model slug if available (may be on the messageEl itself or a descendant)
+  let modelSlug = messageEl.getAttribute('data-message-model-slug');
+  if (!modelSlug) {
+    const modelEl = messageEl.querySelector('[data-message-model-slug]');
+    if (modelEl) {
+      modelSlug = modelEl.getAttribute('data-message-model-slug');
+    }
   }
 
   return {
@@ -862,24 +864,24 @@ async function extractTurnsChatGPT() {
   const turns = [];
   let turnIndex = 0;
 
-  const articles = document.querySelectorAll(SELECTORS.allMessages);
+  const messageEls = document.querySelectorAll(SELECTORS.allMessages);
 
-  for (let i = 0; i < articles.length; i++) {
-    const article = articles[i];
-    const turnType = article.getAttribute('data-turn');
+  for (let i = 0; i < messageEls.length; i++) {
+    const messageEl = messageEls[i];
+    const turnType = messageEl.getAttribute('data-message-author-role');
 
     if (turnType === 'user') {
       // Extract user content from .whitespace-pre-wrap or the message element
       const contentSelector = SELECTORS.userContent || '.whitespace-pre-wrap';
-      const contentEl = article.querySelector(contentSelector);
-      const element = contentEl || article;
+      const contentEl = messageEl.querySelector(contentSelector);
+      const element = contentEl || messageEl;
       turns.push(extractUserTurn(element, turnIndex++));
     } else if (turnType === 'assistant') {
-      turns.push(extractAssistantTurnChatGPT(article, turnIndex++));
+      turns.push(extractAssistantTurnChatGPT(messageEl, turnIndex++));
     }
 
     if (i > 0 && i % 20 === 0) {
-      showProgress(`Extracting turn ${i}/${articles.length}...`);
+      showProgress(`Extracting turn ${i}/${messageEls.length}...`);
       await sleep(0);
     }
   }

--- a/extensions/src/selectors-chatgpt.js
+++ b/extensions/src/selectors-chatgpt.js
@@ -2,15 +2,22 @@
  * Centralized DOM selectors for ChatGPT UI elements.
  * Isolated here for easy maintenance when ChatGPT updates their UI.
  *
- * VERIFIED: 2026-02-28 from real ChatGPT DOM snapshot via Playwright
- * Source: chatgpt.com/c/67bd8097-... (Strangler Pattern in Python)
+ * VERIFIED: 2026-05-23 from two real ChatGPT DOM snapshots saved via
+ * Chrome "Webpage, Single File":
+ *   - Find Missing Number (older, chatgpt.com/c/85301244-...)
+ *   - Contract Review Recommendations (newer, chatgpt.com/c/69eff2c8-...)
+ *
+ * Both samples have zero <article> elements. ChatGPT dropped the
+ * <article data-turn="..."> wrapper at some point between the original
+ * 2026-02-28 verification (issue #15) and now (#116). The per-turn
+ * boundary is the inner div with `data-message-author-role`. We select
+ * on that attribute directly — no article-based selector path.
  */
 
 const SELECTORS = {
   site: 'chatgpt',
 
-  // Conversation container — ChatGPT renders turns as <article> elements
-  // inside a main content area. The articles themselves are the containers.
+  // Conversation container — main content area
   conversationContainer: 'main',
 
   // Session title — ChatGPT uses document.title directly (no suffix)
@@ -19,12 +26,13 @@ const SELECTORS = {
   // Scroll container
   scrollContainer: 'main [class*="overflow-y-auto"], main',
 
-  // Message elements — ChatGPT uses <article> with data-turn attribute
-  userMessage: 'article[data-turn="user"]',
-  assistantMessage: 'article[data-turn="assistant"]',
+  // Message elements — current ChatGPT renders each turn as a div
+  // bearing `data-message-author-role="user"` or `="assistant"`.
+  userMessage: '[data-message-author-role="user"]',
+  assistantMessage: '[data-message-author-role="assistant"]',
 
   // All messages (union of user + assistant)
-  allMessages: 'article[data-turn="user"], article[data-turn="assistant"]',
+  allMessages: '[data-message-author-role="user"], [data-message-author-role="assistant"]',
 
   // Content selectors within messages
   // User text is inside .whitespace-pre-wrap

--- a/tests/content-chatgpt.test.js
+++ b/tests/content-chatgpt.test.js
@@ -93,18 +93,18 @@ describe('extractConversationId (ChatGPT)', () => {
 });
 
 describe('countMessages (ChatGPT)', () => {
-  test('counts user and assistant articles', () => {
+  test('counts user and assistant message elements', () => {
     // NOTE: innerHTML with static test data only (jsdom, no browser, no untrusted content)
     document.body.innerHTML = [
-      '<article data-turn="user">Hello</article>',
-      '<article data-turn="assistant">Hi!</article>',
-      '<article data-turn="user">Follow up</article>',
-      '<article data-turn="assistant">Sure</article>'
+      '<div data-message-author-role="user">Hello</div>',
+      '<div data-message-author-role="assistant">Hi!</div>',
+      '<div data-message-author-role="user">Follow up</div>',
+      '<div data-message-author-role="assistant">Sure</div>'
     ].join('');
     expect(countMessages()).toBe(4);
   });
 
-  test('returns 0 when no articles', () => {
+  test('returns 0 when no message elements', () => {
     document.body.innerHTML = '<div>No conversation here</div>';
     expect(countMessages()).toBe(0);
   });
@@ -112,18 +112,15 @@ describe('countMessages (ChatGPT)', () => {
 
 describe('extractAssistantTurnChatGPT', () => {
   test('extracts markdown content from assistant turn', () => {
-    const article = document.createElement('article');
-    article.setAttribute('data-turn', 'assistant');
-    const markdown = document.createElement('div');
-    markdown.className = 'markdown prose';
-    markdown.textContent = 'The strangler pattern is used for migration.';
     const msgDiv = document.createElement('div');
     msgDiv.setAttribute('data-message-author-role', 'assistant');
     msgDiv.setAttribute('data-message-model-slug', 'gpt-4o');
+    const markdown = document.createElement('div');
+    markdown.className = 'markdown prose';
+    markdown.textContent = 'The strangler pattern is used for migration.';
     msgDiv.appendChild(markdown);
-    article.appendChild(msgDiv);
 
-    const turn = extractAssistantTurnChatGPT(article, 0);
+    const turn = extractAssistantTurnChatGPT(msgDiv, 0);
 
     expect(turn.role).toBe('assistant');
     expect(turn.content).toContain('strangler pattern');
@@ -132,28 +129,25 @@ describe('extractAssistantTurnChatGPT', () => {
   });
 
   test('extracts reasoning label from o1 turn', () => {
-    const article = document.createElement('article');
-    article.setAttribute('data-turn', 'assistant');
+    const msgDiv = document.createElement('div');
+    msgDiv.setAttribute('data-message-author-role', 'assistant');
+    msgDiv.setAttribute('data-message-model-slug', 'o1');
 
-    // Reasoning header
+    // Reasoning header (inside the message element on modern DOM)
     const reasoningDiv = document.createElement('div');
     reasoningDiv.className = 'flex items-start gap-3 pb-2';
     const btn = document.createElement('button');
     btn.textContent = 'Reasoned about architecture for 8 seconds';
     reasoningDiv.appendChild(btn);
-    article.appendChild(reasoningDiv);
+    msgDiv.appendChild(reasoningDiv);
 
     // Response content
     const markdown = document.createElement('div');
     markdown.className = 'markdown prose';
     markdown.textContent = 'Based on your diagram...';
-    const msgDiv = document.createElement('div');
-    msgDiv.setAttribute('data-message-author-role', 'assistant');
-    msgDiv.setAttribute('data-message-model-slug', 'o1');
     msgDiv.appendChild(markdown);
-    article.appendChild(msgDiv);
 
-    const turn = extractAssistantTurnChatGPT(article, 0);
+    const turn = extractAssistantTurnChatGPT(msgDiv, 0);
 
     expect(turn.thinking).toContain('Reasoned about architecture');
     expect(turn.content).toContain('Based on your diagram');
@@ -161,8 +155,8 @@ describe('extractAssistantTurnChatGPT', () => {
   });
 
   test('extracts code blocks from assistant turn', () => {
-    const article = document.createElement('article');
-    article.setAttribute('data-turn', 'assistant');
+    const msgDiv = document.createElement('div');
+    msgDiv.setAttribute('data-message-author-role', 'assistant');
     const markdown = document.createElement('div');
     markdown.className = 'markdown';
     const text = document.createTextNode("Here's the code:");
@@ -173,31 +167,25 @@ describe('extractAssistantTurnChatGPT', () => {
     code.textContent = 'print("hello")';
     pre.appendChild(code);
     markdown.appendChild(pre);
-    const msgDiv = document.createElement('div');
-    msgDiv.setAttribute('data-message-author-role', 'assistant');
     msgDiv.appendChild(markdown);
-    article.appendChild(msgDiv);
 
-    const turn = extractAssistantTurnChatGPT(article, 0);
+    const turn = extractAssistantTurnChatGPT(msgDiv, 0);
 
     expect(turn.content).toContain('```python');
     expect(turn.content).toContain('print("hello")');
   });
 
   test('extracts images from assistant turn', () => {
-    const article = document.createElement('article');
-    article.setAttribute('data-turn', 'assistant');
+    const msgDiv = document.createElement('div');
+    msgDiv.setAttribute('data-message-author-role', 'assistant');
     const markdown = document.createElement('div');
     markdown.className = 'markdown';
     const img = document.createElement('img');
     img.src = 'data:image/png;base64,abc123';
     markdown.appendChild(img);
-    const msgDiv = document.createElement('div');
-    msgDiv.setAttribute('data-message-author-role', 'assistant');
     msgDiv.appendChild(markdown);
-    article.appendChild(msgDiv);
 
-    const turn = extractAssistantTurnChatGPT(article, 0);
+    const turn = extractAssistantTurnChatGPT(msgDiv, 0);
 
     expect(turn.attachments).toHaveLength(1);
     expect(turn.attachments[0].type).toBe('image');
@@ -207,47 +195,41 @@ describe('extractAssistantTurnChatGPT', () => {
 describe('extractTurnsChatGPT', () => {
   test('extracts turns from ChatGPT DOM in order', async () => {
     // Build DOM programmatically to avoid innerHTML
-    const user1 = document.createElement('article');
-    user1.setAttribute('data-turn', 'user');
-    user1.setAttribute('data-testid', 'conversation-turn-1');
+    const user1 = document.createElement('div');
+    user1.setAttribute('data-message-author-role', 'user');
+    user1.setAttribute('data-message-id', 'u1');
     const u1text = document.createElement('div');
     u1text.className = 'whitespace-pre-wrap';
     u1text.textContent = 'Hello ChatGPT';
     user1.appendChild(u1text);
     document.body.appendChild(user1);
 
-    const assist1 = document.createElement('article');
-    assist1.setAttribute('data-turn', 'assistant');
-    assist1.setAttribute('data-testid', 'conversation-turn-2');
+    const assist1 = document.createElement('div');
+    assist1.setAttribute('data-message-author-role', 'assistant');
+    assist1.setAttribute('data-message-id', 'a1');
+    assist1.setAttribute('data-message-model-slug', 'gpt-4o');
     const a1md = document.createElement('div');
     a1md.className = 'markdown';
     a1md.textContent = 'Hi! How can I help?';
     assist1.appendChild(a1md);
-    const a1msg = document.createElement('div');
-    a1msg.setAttribute('data-message-author-role', 'assistant');
-    a1msg.setAttribute('data-message-model-slug', 'gpt-4o');
-    assist1.appendChild(a1msg);
     document.body.appendChild(assist1);
 
-    const user2 = document.createElement('article');
-    user2.setAttribute('data-turn', 'user');
-    user2.setAttribute('data-testid', 'conversation-turn-3');
+    const user2 = document.createElement('div');
+    user2.setAttribute('data-message-author-role', 'user');
+    user2.setAttribute('data-message-id', 'u2');
     const u2text = document.createElement('div');
     u2text.className = 'whitespace-pre-wrap';
     u2text.textContent = 'What is 2+2?';
     user2.appendChild(u2text);
     document.body.appendChild(user2);
 
-    const assist2 = document.createElement('article');
-    assist2.setAttribute('data-turn', 'assistant');
-    assist2.setAttribute('data-testid', 'conversation-turn-4');
+    const assist2 = document.createElement('div');
+    assist2.setAttribute('data-message-author-role', 'assistant');
+    assist2.setAttribute('data-message-id', 'a2');
     const a2md = document.createElement('div');
     a2md.className = 'markdown';
     a2md.textContent = '2+2 equals 4.';
     assist2.appendChild(a2md);
-    const a2msg = document.createElement('div');
-    a2msg.setAttribute('data-message-author-role', 'assistant');
-    assist2.appendChild(a2msg);
     document.body.appendChild(assist2);
 
     const turns = await extractTurnsChatGPT();
@@ -268,25 +250,22 @@ describe('extractTurns dispatches to ChatGPT', () => {
   test('uses ChatGPT extraction when site is chatgpt', async () => {
     useChatGPT();
 
-    const user = document.createElement('article');
-    user.setAttribute('data-turn', 'user');
-    user.setAttribute('data-testid', 'conversation-turn-1');
+    const user = document.createElement('div');
+    user.setAttribute('data-message-author-role', 'user');
+    user.setAttribute('data-message-id', 'u1');
     const utext = document.createElement('div');
     utext.className = 'whitespace-pre-wrap';
     utext.textContent = 'Hello';
     user.appendChild(utext);
     document.body.appendChild(user);
 
-    const assist = document.createElement('article');
-    assist.setAttribute('data-turn', 'assistant');
-    assist.setAttribute('data-testid', 'conversation-turn-2');
+    const assist = document.createElement('div');
+    assist.setAttribute('data-message-author-role', 'assistant');
+    assist.setAttribute('data-message-id', 'a1');
     const amd = document.createElement('div');
     amd.className = 'markdown';
     amd.textContent = 'Hi!';
     assist.appendChild(amd);
-    const amsg = document.createElement('div');
-    amsg.setAttribute('data-message-author-role', 'assistant');
-    assist.appendChild(amsg);
     document.body.appendChild(assist);
 
     const turns = await extractTurns();
@@ -313,8 +292,8 @@ describe('fixture-based ChatGPT extraction', () => {
   });
 
   test('fixture has expected ChatGPT structure', () => {
-    const userMsgs = document.querySelectorAll('article[data-turn="user"]');
-    const assistantMsgs = document.querySelectorAll('article[data-turn="assistant"]');
+    const userMsgs = document.querySelectorAll('[data-message-author-role="user"]');
+    const assistantMsgs = document.querySelectorAll('[data-message-author-role="assistant"]');
     expect(userMsgs.length).toBe(2);
     expect(assistantMsgs.length).toBe(2);
   });

--- a/tests/fixtures/chatgpt-conversation.html
+++ b/tests/fixtures/chatgpt-conversation.html
@@ -5,52 +5,56 @@
   <title>Python lambda closure issue</title>
 </head>
 <body>
+  <!--
+    Synthetic ChatGPT conversation fixture.
+
+    Modeled on real ChatGPT DOM saved 2026-05-23 (issue #116). The per-turn
+    boundary is a <div data-message-author-role="user|assistant">. ChatGPT
+    no longer renders <article data-turn="..."> wrappers around turns; that
+    DOM was current as of the original 2026-02-28 verification but had been
+    dropped by mid-2026. All content is synthetic (no operator data).
+  -->
   <main>
 
     <!-- Turn 1: User message -->
-    <article data-turn="user" data-testid="conversation-turn-1" data-turn-id="6e4495a3-31f4-41b2-b947-f4fd65accbf0" data-scroll-anchor="false">
-      <h5 class="sr-only">You said:</h5>
-      <div class="text-base my-auto mx-auto pt-3">
-        <div>
-          <div class="flex max-w-full flex-col grow">
-            <div class="min-h-8 text-message relative flex w-full flex-col items-end gap-2" data-message-author-role="user" data-message-id="6e4495a3-31f4-41b2-b947-f4fd65accbf0">
-              <div class="flex w-full flex-col gap-1 empty:hidden items-end">
-                <div class="user-message-bubble-color corner-superellipse">
-                  <div class="whitespace-pre-wrap">Can you explain the strangler pattern in software architecture?</div>
-                </div>
+    <div class="text-base my-auto mx-auto pt-3">
+      <div>
+        <div class="flex max-w-full flex-col grow">
+          <div class="min-h-8 text-message relative flex w-full flex-col items-end gap-2" data-message-author-role="user" data-message-id="6e4495a3-31f4-41b2-b947-f4fd65accbf0">
+            <div class="flex w-full flex-col gap-1 empty:hidden items-end">
+              <div class="user-message-bubble-color corner-superellipse">
+                <div class="whitespace-pre-wrap">Can you explain the strangler pattern in software architecture?</div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </article>
+    </div>
 
     <!-- Turn 2: Assistant message (gpt-4o, no thinking) -->
-    <article data-turn="assistant" data-testid="conversation-turn-2" data-turn-id="1ea20cdd-dac4-4ba9-b2fa-d270c0eae306" data-scroll-anchor="false">
-      <h6 class="sr-only">ChatGPT said:</h6>
-      <div class="text-base my-auto mx-auto">
-        <div>
-          <div class="flex max-w-full flex-col grow">
-            <div class="min-h-8 text-message relative flex w-full flex-col items-end gap-2" data-message-author-role="assistant" data-message-id="4fb3a42d-55f2-4a29-928c-07d078db1fbf" data-message-model-slug="gpt-4o">
-              <div class="flex w-full flex-col gap-1 empty:hidden first:pt-[1px]">
-                <div class="markdown prose dark:prose-invert w-full wrap-break-word">
-                  <p>The <strong>Strangler Pattern</strong> is used for incrementally replacing a legacy system.</p>
-                  <p>Key benefits include reduced risk and continuous delivery.</p>
-                  <pre class="overflow-visible! px-0!">
-                    <div class="relative w-full my-4">
-                      <div>
-                        <div class="relative">
+    <div class="text-base my-auto mx-auto">
+      <div>
+        <div class="flex max-w-full flex-col grow">
+          <div class="min-h-8 text-message relative flex w-full flex-col items-end gap-2" data-message-author-role="assistant" data-message-id="4fb3a42d-55f2-4a29-928c-07d078db1fbf" data-message-model-slug="gpt-4o">
+            <div class="flex w-full flex-col gap-1 empty:hidden first:pt-[1px]">
+              <div class="markdown prose dark:prose-invert w-full wrap-break-word">
+                <p>The <strong>Strangler Pattern</strong> is used for incrementally replacing a legacy system.</p>
+                <p>Key benefits include reduced risk and continuous delivery.</p>
+                <pre class="overflow-visible! px-0!">
+                  <div class="relative w-full my-4">
+                    <div>
+                      <div class="relative">
+                        <div class="h-full min-h-0 min-w-0">
                           <div class="h-full min-h-0 min-w-0">
-                            <div class="h-full min-h-0 min-w-0">
-                              <div class="border border-token-border-light rounded-3xl">
-                                <div class="h-full w-full overflow-clip rounded-3xl">
-                                  <div class="sticky z-2 select-none">
-                                    <div class="flex w-full items-center justify-between py-1.5 ps-4 pe-1.5 bg-token-bg-elevated-secondary">
-                                      <div class="flex text-sm font-medium text-token-text-primary">Python</div>
-                                    </div>
+                            <div class="border border-token-border-light rounded-3xl">
+                              <div class="h-full w-full overflow-clip rounded-3xl">
+                                <div class="sticky z-2 select-none">
+                                  <div class="flex w-full items-center justify-between py-1.5 ps-4 pe-1.5 bg-token-bg-elevated-secondary">
+                                    <div class="flex text-sm font-medium text-token-text-primary">Python</div>
                                   </div>
-                                  <div class="overflow-y-auto p-4">
-                                    <code data-language="python">class StranglerFacade:
+                                </div>
+                                <div class="overflow-y-auto p-4">
+                                  <code data-language="python">class StranglerFacade:
     def __init__(self, legacy, modern):
         self.legacy = legacy
         self.modern = modern
@@ -59,7 +63,6 @@
         if self.modern.can_handle(request):
             return self.modern.handle(request)
         return self.legacy.handle(request)</code>
-                                  </div>
                                 </div>
                               </div>
                             </div>
@@ -67,62 +70,56 @@
                         </div>
                       </div>
                     </div>
-                  </pre>
-                </div>
+                  </div>
+                </pre>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </article>
+    </div>
 
     <!-- Turn 3: User message with image -->
-    <article data-turn="user" data-testid="conversation-turn-3" data-turn-id="93bb0fa3-90ea-47c7-9026-38c5319e7826" data-scroll-anchor="false">
-      <h5 class="sr-only">You said:</h5>
-      <div class="text-base my-auto mx-auto pt-12">
-        <div>
-          <div class="flex max-w-full flex-col grow">
-            <div class="min-h-8 text-message relative flex w-full flex-col items-end gap-2" data-message-author-role="user" data-message-id="93bb0fa3-90ea-47c7-9026-38c5319e7826">
-              <div class="flex w-full flex-col gap-1 empty:hidden items-end">
-                <div class="user-message-bubble-color corner-superellipse">
-                  <div class="whitespace-pre-wrap">Here is my current architecture. How would I apply the strangler pattern?
-                    <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==" alt="architecture diagram">
-                  </div>
+    <div class="text-base my-auto mx-auto pt-12">
+      <div>
+        <div class="flex max-w-full flex-col grow">
+          <div class="min-h-8 text-message relative flex w-full flex-col items-end gap-2" data-message-author-role="user" data-message-id="93bb0fa3-90ea-47c7-9026-38c5319e7826">
+            <div class="flex w-full flex-col gap-1 empty:hidden items-end">
+              <div class="user-message-bubble-color corner-superellipse">
+                <div class="whitespace-pre-wrap">Here is my current architecture. How would I apply the strangler pattern?
+                  <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==" alt="architecture diagram">
                 </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </article>
+    </div>
 
     <!-- Turn 4: Assistant message (o1, with reasoning) -->
-    <article data-turn="assistant" data-testid="conversation-turn-4" data-turn-id="d096d7e7-2eab-4483-9969-434c5f5615ea" data-scroll-anchor="false">
-      <h6 class="sr-only">ChatGPT said:</h6>
-      <div class="text-base my-auto mx-auto">
-        <div>
-          <div class="flex items-start gap-3 pb-2">
-            <div class="flex w-full flex-col">
-              <div class="flex w-full items-center justify-between">
-                <button type="button" class="group inline-flex max-w-full items-center rounded-md">
-                  <span class="text-token-text-tertiary">Reasoned about strangler pattern migration for 8 seconds</span>
-                </button>
+    <div class="text-base my-auto mx-auto">
+      <div>
+        <div class="flex max-w-full flex-col grow">
+          <div class="min-h-8 text-message relative flex w-full flex-col items-end gap-2" data-message-author-role="assistant" data-message-id="d096d7e7-2eab-4483-9969-434c5f5615ea" data-message-model-slug="o1">
+            <div class="flex items-start gap-3 pb-2">
+              <div class="flex w-full flex-col">
+                <div class="flex w-full items-center justify-between">
+                  <button type="button" class="group inline-flex max-w-full items-center rounded-md">
+                    <span class="text-token-text-tertiary">Reasoned about strangler pattern migration for 8 seconds</span>
+                  </button>
+                </div>
               </div>
             </div>
-          </div>
-          <div class="flex max-w-full flex-col grow">
-            <div class="min-h-8 text-message relative flex w-full flex-col items-end gap-2" data-message-author-role="assistant" data-message-id="d096d7e7-2eab-4483-9969-434c5f5615ea" data-message-model-slug="o1">
-              <div class="flex w-full flex-col gap-1 empty:hidden first:pt-[1px]">
-                <div class="markdown prose dark:prose-invert w-full wrap-break-word">
-                  <p>Based on your diagram, I'd recommend starting with the API gateway layer as your strangler facade.</p>
-                  <p>Route new traffic through the modern service while keeping the legacy system as a fallback.</p>
-                </div>
+            <div class="flex w-full flex-col gap-1 empty:hidden first:pt-[1px]">
+              <div class="markdown prose dark:prose-invert w-full wrap-break-word">
+                <p>Based on your diagram, I'd recommend starting with the API gateway layer as your strangler facade.</p>
+                <p>Route new traffic through the modern service while keeping the legacy system as a fallback.</p>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </article>
+    </div>
 
   </main>
 </body>


### PR DESCRIPTION
## Summary

ChatGPT extraction has been broken on current chatgpt.com DOM since ChatGPT dropped the `<article data-turn="...">` wrapper somewhere between Feb 2026 (when our selectors were last verified) and now. Verified zero `<article>` elements across two real conversation saves spanning that window — every ChatGPT user has been getting empty extractions.

Swapping to `[data-message-author-role]` (the stable per-turn boundary across both samples) restores extraction.

- `selectors-chatgpt.js`: article-based selectors → `[data-message-author-role]` selectors; verification header dated 2026-05-23 with source URLs
- `content.js`: `extractTurnsChatGPT` reads `data-message-author-role` instead of `data-turn`; `extractAssistantTurnChatGPT` checks for `data-message-model-slug` on the message div itself before descending; variable renames (`article` → `messageEl`); `countMessages` ChatGPT branch updated
- `tests/content-chatgpt.test.js`: tests rewritten to build DOM with the new shape (single `<div data-message-author-role>` per turn instead of nested article+inner div). Test expectations unchanged.
- `tests/fixtures/chatgpt-conversation.html`: drop `<article>` wrappers, move reasoning label inside the assistant message div (where modern DOM places it). Synthetic content unchanged.
- `manifest.json`: 1.3.3 → 1.3.4 (versioning policy: bugfix = patch bump on every `extensions/` change)

## Test plan

- [x] All 19 ChatGPT-specific tests pass
- [x] Full suite: 267/267 across 12 suites
- [x] Selectors verified against two real ChatGPT conversation DOM saves (Find Missing Number = older, Contract Review = newer)
- [ ] Manual smoke test in Chrome on a fresh ChatGPT conversation post-merge (will do when reloading the extension)

## Why this matters

`#116` is the second of three launch-blocker DOM modernization issues opened today (alongside #114 Claude, #115 Gemini downgraded to cleanup). The launch sequence is gated on #114 + #116 landing.

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)