### PR TITLE
fix(claude): modernize selector to font-claude-response (era-stable boundary)

### DIFF
--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Clio",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Extract full Gemini, Claude, and ChatGPT conversations to JSON with images",
   "permissions": [
     "activeTab",

--- a/extensions/src/content.js
+++ b/extensions/src/content.js
@@ -257,10 +257,11 @@ function resetScrollConfig() {
 function countMessages() {
   const site = getSite();
   if (site === 'claude') {
-    // Assistant turns: one .row-start-2 per turn. Do not use action-bar-copy
-    // (appears on user messages too, inflated the count — issue #32).
+    // Assistant turns: one .font-claude-response per turn. Do not use
+    // action-bar-copy (appears on user messages too, inflated the count —
+    // issue #32). Do not use .row-start-2 (broken on pre-redesign Claude — #114).
     const userMsgs = document.querySelectorAll('[data-testid="user-message"]');
-    const assistantMsgs = document.querySelectorAll('.row-start-2');
+    const assistantMsgs = document.querySelectorAll('.font-claude-response:not(.font-claude-response-body)');
     return userMsgs.length + assistantMsgs.length;
   }
   if (site === 'chatgpt') {
@@ -791,8 +792,12 @@ async function extractTurnsClaude() {
     if (isUser) {
       turns.push(extractUserTurn(element, turnIndex++));
     } else {
-      const turnContainer = findClaudeAssistantContainer(element);
-      turns.push(extractAssistantTurnClaude(turnContainer, turnIndex++));
+      // element IS the per-turn container (.font-claude-response) — no
+      // walking-up needed. Pre-2026-05 code used .row-start-2 as the
+      // assistant-turn selector and then walked up via
+      // findClaudeAssistantContainer to find the bounding turn. With the
+      // new selector that step is unnecessary (#114).
+      turns.push(extractAssistantTurnClaude(element, turnIndex++));
     }
 
     if (i > 0 && i % 20 === 0) {

--- a/extensions/src/selectors-claude.js
+++ b/extensions/src/selectors-claude.js
@@ -2,12 +2,27 @@
  * Centralized DOM selectors for Claude.ai UI elements.
  * Isolated here for easy maintenance when Claude updates their UI.
  *
- * VERIFIED: 2026-04-18 from real Claude DOM via DevTools ancestor-path dump (issue #32).
+ * VERIFIED: 2026-05-23 against three real Claude conversation DOM saves
+ * spanning two DOM eras:
+ *   - OLDEST: "AI for Construction" — pre-redesign Claude (15 turns)
+ *   - MODERN-prose: "Haiku about rain" (1 turn, no tools)
+ *   - MODERN-widget: Recruiter email artifact (1 turn, tool-call + email widget)
  *
- * assistantMessage uses `.row-start-2` (response-content row) because Claude
- * places `[data-testid="action-bar-copy"]` on BOTH user and assistant messages,
- * so the copy-button selector would double-count. `.row-start-2` appears
- * exactly once per assistant turn and never inside a user-message subtree.
+ * Per-turn assistant boundary is `.font-claude-response` (the outer div
+ * containing all response content for a single turn). Verified stable in
+ * BOTH eras:
+ *   - OLDEST: 15 occurrences (matches 15 turns)
+ *   - MODERN: 1 per turn
+ *
+ * Previously this selector was `.row-start-2`. That class:
+ *   - does NOT exist in pre-redesign Claude DOM (0 matches in OLDEST sample)
+ *   - DOES exist in modern Claude but as a sub-element (a grid row for tool
+ *     calls), not as the per-turn boundary
+ * Using `.row-start-2` meant zero turns extracted on older conversations,
+ * and the right-count-for-the-wrong-reason on modern ones.
+ *
+ * User-message selector `[data-testid="user-message"]` is stable across
+ * both eras.
  */
 
 const SELECTORS = {
@@ -24,19 +39,26 @@ const SELECTORS = {
 
   // Message elements
   userMessage: '[data-testid="user-message"]',
-  // One .row-start-2 per assistant turn (the response-content row).
+  // One .font-claude-response per assistant turn — the outer response-container.
+  // Stable across both pre-redesign (oldest) and modern Claude DOM.
   // Do NOT use [data-testid="action-bar-copy"] — Claude renders that on user
   // messages too, which caused duplicate assistant entries (issue #32).
-  assistantMessage: '.row-start-2',
+  // Do NOT use [class="font-claude-response-body"] — that's per paragraph, not per turn.
+  assistantMessage: '.font-claude-response:not(.font-claude-response-body)',
 
   // All messages (union of user + assistant)
-  allMessages: '[data-testid="user-message"], .row-start-2',
+  allMessages: '[data-testid="user-message"], .font-claude-response:not(.font-claude-response-body)',
 
   // Expandable content — thinking toggles in Claude
   expandButton: null, // Claude doesn't use generic expand buttons
   thinkingToggle: '.row-start-1 button[aria-expanded="false"]',
 
   // Thinking and response content within assistant turns
+  // .row-start-1 (thinking) and .row-start-2 (response wrapper) exist only in
+  // the modern grid-style DOM (when Claude renders a 2-row grid for tool calls
+  // or thinking). On older Claude DOM these are absent — the assistant
+  // response is just paragraphs directly inside .font-claude-response, and
+  // the thinking/response split logic below is a no-op (which is correct).
   thinkingContent: '.row-start-1',
   responseContent: '.row-start-2',
 

--- a/tests/content-claude.test.js
+++ b/tests/content-claude.test.js
@@ -94,19 +94,19 @@ describe('extractConversationId (Claude)', () => {
 });
 
 describe('countMessages (Claude)', () => {
-  test('counts user and assistant messages (row-start-2)', () => {
+  test('counts user and assistant messages (font-claude-response)', () => {
     document.body.innerHTML = [
       '<div data-testid="user-message">Hello</div>',
-      '<div class="row-start-2">First response</div>',
+      '<div class="font-claude-response">First response</div>',
       '<div data-testid="user-message">Follow up</div>',
-      '<div class="row-start-2">Second response</div>'
+      '<div class="font-claude-response">Second response</div>'
     ].join('');
     expect(countMessages()).toBe(4);
   });
 
   test('does NOT count action-bar-copy buttons (user messages have them too)', () => {
     // Regression for #32: copy buttons appear on both user and assistant
-    // messages. Only .row-start-2 identifies an assistant turn.
+    // messages. Only .font-claude-response identifies an assistant turn.
     document.body.innerHTML = [
       '<div data-testid="user-message">Hello</div>',
       '<button data-testid="action-bar-copy"></button>',
@@ -373,7 +373,7 @@ describe('extractTurnsClaude', () => {
     document.body.appendChild(user1);
 
     const grid1 = document.createElement('div');
-    grid1.className = 'grid-container';
+    grid1.className = 'font-claude-response';
     const copy1 = document.createElement('div');
     copy1.setAttribute('data-testid', 'action-bar-copy');
     grid1.appendChild(copy1);
@@ -389,7 +389,7 @@ describe('extractTurnsClaude', () => {
     document.body.appendChild(user2);
 
     const grid2 = document.createElement('div');
-    grid2.className = 'grid-container';
+    grid2.className = 'font-claude-response';
     const copy2 = document.createElement('div');
     copy2.setAttribute('data-testid', 'action-bar-copy');
     grid2.appendChild(copy2);
@@ -435,7 +435,7 @@ describe('extractTurnsClaude with shared grid ancestor (regression #25)', () => 
 
     function appendAssistant(thinkingText, responseText) {
       const perTurn = document.createElement('div');
-      perTurn.className = 'message-layout';
+      perTurn.className = 'font-claude-response';
 
       const thinking = document.createElement('div');
       thinking.className = 'row-start-1';
@@ -540,7 +540,7 @@ describe('extractTurnsClaude with real Claude DOM shape (regression #32)', () =>
       } else {
         const outer = document.createElement('div');
         const group = document.createElement('div');
-        group.className = 'group';
+        group.className = 'group font-claude-response';
         if (turn.thinking) {
           const think = document.createElement('div');
           think.className = 'row-start-1';
@@ -649,7 +649,7 @@ describe('extractTurns dispatches by site', () => {
     document.body.appendChild(user);
 
     const grid = document.createElement('div');
-    grid.className = 'grid-container';
+    grid.className = 'font-claude-response';
     const copy = document.createElement('div');
     copy.setAttribute('data-testid', 'action-bar-copy');
     grid.appendChild(copy);
@@ -685,7 +685,7 @@ describe('fixture-based Claude extraction', () => {
 
   test('fixture has expected Claude structure', () => {
     const userMsgs = document.querySelectorAll('[data-testid="user-message"]');
-    const assistantMsgs = document.querySelectorAll('[data-testid="action-bar-copy"]');
+    const assistantMsgs = document.querySelectorAll('.font-claude-response:not(.font-claude-response-body)');
     expect(userMsgs.length).toBe(2);
     expect(assistantMsgs.length).toBe(2);
   });

--- a/tests/fixtures/claude-conversation.html
+++ b/tests/fixtures/claude-conversation.html
@@ -5,6 +5,18 @@
   <title>Engineering-first AI solution - Claude</title>
 </head>
 <body>
+  <!--
+    Synthetic Claude conversation fixture for #114 modernization.
+
+    Wraps each assistant turn in `<div class="font-claude-response">` (the
+    stable per-turn boundary across both pre-redesign and modern Claude DOM).
+    Turn 1 mirrors the modern grid-style internal layout (.row-start-1 for
+    thinking, .row-start-2 for response with nested response-body).
+    Turn 2 mirrors the pre-redesign layout (paragraphs directly inside the
+    response container, no .row-start-1/.row-start-2 grid).
+
+    All content is synthetic — no operator data.
+  -->
   <div class="flex-1 flex flex-col max-w-3xl">
 
     <!-- Turn 1: User message -->
@@ -12,22 +24,26 @@
       Hello Claude. Can you help me design a system architecture?
     </div>
 
-    <!-- Turn 1: Assistant response with thinking -->
-    <div class="grid-container" style="display: grid;">
-      <div data-testid="action-bar-copy"></div>
-      <div class="row-start-1">
-        <p>Analyzing the request for system architecture design. The user wants a comprehensive approach.</p>
-        <button class="group/row">Get current time</button>
-      </div>
-      <div class="row-start-2">
-        <p>I'd be happy to help you design a system architecture. Here's a starting point:</p>
-        <pre><code data-language="python">class SystemArchitecture:
+    <!-- Turn 1: Assistant response WITH thinking (modern grid-style) -->
+    <div class="font-claude-response relative leading-[1.65rem]">
+      <div class="grid-container" style="display: grid;">
+        <div data-testid="action-bar-copy"></div>
+        <div class="row-start-1">
+          <p>Analyzing the request for system architecture design. The user wants a comprehensive approach.</p>
+          <button class="group/row">Get current time</button>
+        </div>
+        <div class="row-start-2">
+          <div class="row-start-1 col-start-1 relative z-[2]">
+            <p>I'd be happy to help you design a system architecture. Here's a starting point:</p>
+            <pre><code data-language="python">class SystemArchitecture:
     def __init__(self):
         self.components = []
 
     def add_component(self, name):
         self.components.append(name)</code></pre>
-        <p>Let me know what specific requirements you have.</p>
+            <p>Let me know what specific requirements you have.</p>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -37,15 +53,12 @@
       <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==" alt="architecture diagram">
     </div>
 
-    <!-- Turn 2: Assistant response without thinking -->
-    <div class="grid-container" style="display: grid;">
-      <div data-testid="action-bar-copy"></div>
-      <div class="row-start-2">
-        <p>For real-time data processing, I recommend using an event-driven architecture with message queues. The key components would be:</p>
-        <p>1. An ingestion layer for incoming data streams</p>
-        <p>2. A processing engine for transformations</p>
-        <p>3. A storage layer optimized for time-series data</p>
-      </div>
+    <!-- Turn 2: Assistant response WITHOUT thinking (pre-redesign style) -->
+    <div class="font-claude-response relative leading-[1.65rem]">
+      <p class="font-claude-response-body">For real-time data processing, I recommend using an event-driven architecture with message queues. The key components would be:</p>
+      <p class="font-claude-response-body">1. An ingestion layer for incoming data streams</p>
+      <p class="font-claude-response-body">2. A processing engine for transformations</p>
+      <p class="font-claude-response-body">3. A storage layer optimized for time-series data</p>
     </div>
 
   </div>


### PR DESCRIPTION
## Summary

The April 2026 verification (issue #32) keyed Clio's Claude extraction off `.row-start-2`. Audit 2026-05-23 against three real Claude conversation DOM saves showed that selector is broken for pre-redesign Claude and only coincidentally correct for modern Claude (where `.row-start-2` is a sub-element grid row, not the per-turn boundary).

| Sample | Turns | `.row-start-2` | `.font-claude-response` (outer) |
|--------|-------|----------------|----------------------------------|
| AI for Construction (OLDEST) | 15 | **0** | **15** |
| Haiku about rain (modern, plain prose) | 1 | 1 | **1** |
| Recruiter widget (modern, tool call + email artifact) | 1 | 1 | **1** |

`.font-claude-response` is the stable per-turn boundary across both eras. Switch the assistant-message selector to it (with `:not(.font-claude-response-body)` to avoid matching the per-paragraph variant).

## Test plan

- [x] All 32 Claude-specific tests pass
- [x] Full suite: 267/267 across 12 suites
- [x] Selectors verified against three real conversation DOM saves spanning two DOM eras
- [ ] Manual smoke test in Chrome on a fresh Claude conversation post-merge

## Internal extraction logic preserved

`.row-start-1` (thinking) and `.row-start-2` (response wrapper) still describe valid modern-DOM sub-structures. The extraction logic inside `extractAssistantTurnClaude` operates on them as before — modern Claude has them, pre-redesign Claude doesn't, and the `querySelector` calls return null in the latter case (handled).

The `findClaudeAssistantContainer` walking-up step is dropped from `extractTurnsClaude` — when the matched element already IS the per-turn boundary (`.font-claude-response`), walking up adds no signal and can drift wrong.

## Why this matters

`#114` is the third and final launch-blocker DOM modernization issue. With this and #116 (ChatGPT, merged in PR #118) landed, all three sites should extract correctly on current and historical DOM. `#43` (Claude artifact widget chrome bleed) is unblocked.

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)