### PR TITLE
fix(claude): strip artifact-widget chrome from extracted content (#43)

### DIFF
--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Clio",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Extract full Gemini, Claude, and ChatGPT conversations to JSON with images",
   "permissions": [
     "activeTab",

--- a/extensions/src/content.js
+++ b/extensions/src/content.js
@@ -661,6 +661,48 @@ function extractAssistantTurn(element, index) {
 }
 
 /**
+ * Strip Claude artifact-widget chrome from a cloned response container.
+ *
+ * Claude renders interactive artifact cards (email drafts, document drafts,
+ * code) inside the assistant response. The card has a distinctive class
+ * signature: `font-ui` + `rounded-2xl` + `rounded-t-3xl` + `overflow-hidden`
+ * + `border-border-300` — verified 2026-05-23 against a real Recruiter
+ * email-draft widget (issue #43).
+ *
+ * Inside each widget, two kinds of text were leaking into the extracted
+ * content:
+ *
+ *   1. Button labels — variant-selector tabs ("Warm decline, door open" /
+ *      "Brief, final close") and action buttons ("Send via Gmail") have
+ *      visible text inside `<span>` children, which textContent captures
+ *      as if it were prose.
+ *   2. Adjacent label+value pairs — a `<label>Subject:</label>` element
+ *      next to its value renders as readable "Subject: Re: Your inquiry"
+ *      in the UI but textContent concatenates them with no separator:
+ *      "Subject:Re: Your inquiry".
+ *
+ * Fix: remove all `<button>` elements inside any matched widget (none of
+ * them are prose), and append a single space inside each `<label>` so the
+ * subsequent value reads with proper separation.
+ *
+ * @param {Element} rootEl - cloned response container to modify in place
+ */
+function stripArtifactWidgetChrome(rootEl) {
+  if (!rootEl || typeof rootEl.querySelectorAll !== 'function') return;
+  const widgetRoots = rootEl.querySelectorAll(
+    '.font-ui.rounded-2xl.rounded-t-3xl.overflow-hidden.border-border-300'
+  );
+  if (!widgetRoots.length) return;
+  const doc = rootEl.ownerDocument || document;
+  for (const widget of widgetRoots) {
+    widget.querySelectorAll('button').forEach(btn => btn.remove());
+    widget.querySelectorAll('label').forEach(label => {
+      label.appendChild(doc.createTextNode(' '));
+    });
+  }
+}
+
+/**
  * Extract a single Claude assistant turn.
  * Claude uses .row-start-1 for thinking and .row-start-2 for response content.
  * Tool use is indicated by buttons with group/row class inside .row-start-1.
@@ -708,6 +750,7 @@ function extractAssistantTurnClaude(element, index) {
       el.remove();
     }
   });
+  stripArtifactWidgetChrome(contentClone);
   const content = extractTextContent(contentClone);
 
   const turn = {

--- a/tests/content-claude.test.js
+++ b/tests/content-claude.test.js
@@ -362,6 +362,99 @@ describe('extractAssistantTurnClaude', () => {
     // With real commentary captured, this is NOT a thinking-only turn
     expect(turn.type).toBeUndefined();
   });
+
+  test('strips artifact-widget chrome (Send via Gmail, tab labels) and separates label/value (issue #43)', () => {
+    // Real DOM verified 2026-05-23: Claude email-draft artifact widget
+    // has a distinctive class signature on its outer container.
+    // Synthetic fixture mirrors structural shape; content is invented.
+    const turnWrapper = document.createElement('div');
+    turnWrapper.className = 'font-claude-response';
+
+    const widget = document.createElement('div');
+    widget.className = 'font-ui bg-bg-000 rounded-2xl rounded-t-3xl overflow-hidden border-border-300 border';
+
+    // Variant-selector tab bar with text-bearing buttons
+    const tabBar = document.createElement('div');
+    tabBar.className = 'flex gap-1 p-1.5 border-b-0.5 border-border-300 overflow-x-auto';
+    const tabA = document.createElement('button');
+    tabA.className = 'group/row';
+    tabA.textContent = 'Warm decline, door open';
+    const tabB = document.createElement('button');
+    tabB.className = 'group/row';
+    tabB.textContent = 'Brief, final close';
+    tabBar.appendChild(tabA);
+    tabBar.appendChild(tabB);
+    widget.appendChild(tabBar);
+
+    // Subject row — label + value, no whitespace separator in textContent
+    const subjectRow = document.createElement('div');
+    subjectRow.className = 'flex items-center border-b-0.5 border-border-300';
+    const subjectLabel = document.createElement('label');
+    subjectLabel.textContent = 'Subject:';
+    const subjectValue = document.createElement('span');
+    subjectValue.textContent = 'Re: Your inquiry';
+    subjectRow.appendChild(subjectLabel);
+    subjectRow.appendChild(subjectValue);
+    widget.appendChild(subjectRow);
+
+    // Body
+    const body = document.createElement('div');
+    const p1 = document.createElement('p');
+    p1.textContent = 'Hi [Name],';
+    const p2 = document.createElement('p');
+    p2.textContent = "Thanks for reaching out. It isn't the right fit for me right now.";
+    const p3 = document.createElement('p');
+    p3.textContent = 'Best, Marty';
+    body.appendChild(p1);
+    body.appendChild(p2);
+    body.appendChild(p3);
+    widget.appendChild(body);
+
+    // Action bar — Send via Gmail and three icon-only buttons
+    const actionBar = document.createElement('div');
+    actionBar.className = 'flex items-center justify-end gap-2 px-2 py-2';
+    const copyBtn = document.createElement('button');
+    copyBtn.setAttribute('aria-label', 'Copy message');
+    const resetBtn = document.createElement('button');
+    resetBtn.setAttribute('aria-label', 'Reset changes');
+    const backBtn = document.createElement('button');
+    backBtn.setAttribute('aria-label', 'Back to chat');
+    const sendBtn = document.createElement('button');
+    const sendSpan = document.createElement('span');
+    sendSpan.textContent = 'Send via Gmail';
+    sendBtn.appendChild(sendSpan);
+    actionBar.appendChild(copyBtn);
+    actionBar.appendChild(resetBtn);
+    actionBar.appendChild(backBtn);
+    actionBar.appendChild(sendBtn);
+    widget.appendChild(actionBar);
+
+    turnWrapper.appendChild(widget);
+
+    // Post-widget commentary prose (sibling of widget, still part of turn)
+    const commentary = document.createElement('p');
+    commentary.textContent = 'Two options above — one keeps the door open.';
+    turnWrapper.appendChild(commentary);
+
+    const turn = extractAssistantTurnClaude(turnWrapper, 0);
+
+    // Widget chrome stripped
+    expect(turn.content).not.toContain('Send via Gmail');
+    expect(turn.content).not.toContain('Warm decline, door open');
+    expect(turn.content).not.toContain('Brief, final close');
+
+    // Subject label and value separated with whitespace
+    expect(turn.content).toContain('Subject: Re: Your inquiry');
+    expect(turn.content).not.toContain('Subject:Re: Your inquiry');
+
+    // Body preserved
+    expect(turn.content).toContain('Hi [Name]');
+    expect(turn.content).toContain('right fit for me');
+    expect(turn.content).toContain('Best, Marty');
+
+    // Post-widget commentary preserved
+    expect(turn.content).toContain('Two options above');
+  });
 });
 
 describe('extractTurnsClaude', () => {


### PR DESCRIPTION
## Summary

The Claude artifact widget (email draft, document draft, etc.) renders text-bearing buttons that leak into extracted message content. Real DOM verified 2026-05-23 against a Recruiter email-draft conversation. The widget root has a stable class signature: `font-ui rounded-2xl rounded-t-3xl overflow-hidden border-border-300`.

Three bleed sources, all fixed:

| Leak | Example output before | After |
|------|-----------------------|-------|
| Variant tab labels | `Warm decline, door open Brief, final close Subject:...` | (stripped) |
| Send-via-Gmail button | `Best,\nMarty\nSend via Gmail[Model:...]` | `Best,\nMarty\n[Model:...]` |
| Subject label/value glued | `Subject:Re: Your inquiry` | `Subject: Re: Your inquiry` |

## Implementation

New helper `stripArtifactWidgetChrome(rootEl)` in `content.js`:
- Finds widget roots by the class signature
- Removes all `<button>` descendants (none are prose — variant tabs and action buttons all live there)
- Appends a single space inside each `<label>` so textContent renders with proper separation

Called from `extractAssistantTurnClaude` after the existing thinking-row removal pass, before the final textContent extraction.

## Test plan

- [x] New regression test builds a synthetic widget with all chrome elements + verifies the strip works (all four bleed cases asserted)
- [x] Full suite: 268/268 across 12 suites
- [x] Selector verified against a real Claude email-draft widget DOM dump

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)