### PR TITLE
docs(selectors-gemini): document era-stability + fallback rationale (#115)

### DIFF
--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Clio",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Extract full Gemini, Claude, and ChatGPT conversations to JSON with images",
   "permissions": [
     "activeTab",

--- a/extensions/src/selectors.js
+++ b/extensions/src/selectors.js
@@ -2,8 +2,24 @@
  * Centralized DOM selectors for Gemini UI elements.
  * Isolated here for easy maintenance when Gemini updates their UI.
  *
- * VERIFIED: 2026-01-19 from real Gemini DOM snapshot
- * Source: docs/html-input/Google Gemini.htm
+ * VERIFIED: 2026-05-23 against three real Gemini conversation DOM saves
+ * (issue #115):
+ *   - AgentOS Refactor (Jan/Feb 2026, oldest) — 10 turns
+ *   - IEEE Document Title (current) — 10 turns
+ *   - Power Sector Organizations (current) — 1 turn
+ *
+ * In all three samples the primary custom elements work cleanly:
+ *   <user-query> count == <model-response> count == turn count
+ *
+ * `[data-message-author-role]` did NOT match in any of the three samples —
+ * those union-fallbacks have been zero-match in real Gemini DOM for at
+ * least 4 months. Kept in the union anyway: extension tests
+ * (auto-scroll, large-conversation, validateSelectors) deliberately
+ * model an alternate Gemini DOM shape via `data-message-author-role`,
+ * treating the fallback as a contractual support path for hypothetical
+ * Gemini variants. Not safe to retire without re-aligning those tests.
+ *
+ * Originally last verified 2026-01-19.
  *
  * LLD Reference: docs/reports/1/lld-clio.md Section 6.1
  */
@@ -13,7 +29,6 @@ const SELECTORS = {
 
   // Conversation structure
   // VERIFIED: <div class="conversation-container message-actions-hover-boundary" id="...">
-  // FIXED: Removed 'main' - too broad, causes clicking of global UI elements
   conversationContainer: '.conversation-container, [data-conversation-id]',
   // VERIFIED: <span class="conversation-title gds-title-m">
   sessionTitle: '.conversation-title, h1[data-conversation-title], h1',


### PR DESCRIPTION
## Summary

Re-scoped from "retire dead Gemini fallbacks" to "document the verification + explain why the fallbacks stay" after discovering that auto-scroll, large-conversation, and validateSelectors tests deliberately rely on the `data-message-author-role` selectors as an alternate-DOM contract.

Audit 2026-05-23 against 3 real Gemini conversation DOM saves spanning Jan/Feb 2026 (AgentOS Refactor, oldest) to current (IEEE Title, Power Sector) confirmed `<user-query>` / `<model-response>` selectors are era-stable. `[data-message-author-role]` returns zero across all three samples. But removing those fallbacks would break 5 tests, so:

- This PR is **documentation-only** in `selectors.js` — header comment now reflects the verification date, the samples used, and explicit rationale for the fallback retention
- `manifest.json` bumped 1.3.6 → 1.3.7 per versioning policy (any `extensions/` touch)
- Future follow-up: re-align tests to use `<user-query>` / `<model-response>` directly, then the fallbacks can retire cleanly

## Test plan

- [x] Full suite: 268/268 across 12 suites — no functional change, just documentation

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)