### PR TITLE
chore(gitignore): broaden data/ from per-file to repo-wide (#122)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,8 @@ docs/html-input/
 # Session logs (may contain sensitive info)
 docs/session-logs/
 
-# Unleashed session transcripts (auto-generated, untracked)
-data/unleashed/
-
-# Handoff logs
-data/handoff-log.md
+# Session data — extractions, DOM dumps, handoffs, pickups, session
+# transcripts. Contains verbatim conversation content (extracted ZIPs,
+# saved HTML pages for debugging, etc.). NEVER tracked. Always-on
+# broad rule supersedes the narrow per-file rules below.
+data/


### PR DESCRIPTION
## Summary

Replace the two narrow `.gitignore` rules (`data/unleashed/`, `data/handoff-log.md`) with a single broad `data/`. Any file under `data/` is now gitignored at the repo level.

Discovered during #114/#43 audit work: a real Claude conversation page-save was successfully staged by `git add data/claude-artifact-page.html` before being caught — the old narrow rules didn't cover it. The fleet-wide `~/.gitignore_global` `/data/` rule (added same day) provides a second layer, but in-repo coverage is the stronger primary defense.

No file behavior changes — nothing in `data/` was tracked, so this is purely defensive widening.

## Test plan

- [x] `git check-ignore -v data/<any-file>` returns `.gitignore:39:data/` for any path
- [x] `git status` is unchanged (nothing was tracked under `data/`)

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)