### PR TITLE
docs(cws): draft listing copy + screenshot-asset placeholder (refs #92)

### DIFF
--- a/docs/assets/store/README.md
+++ b/docs/assets/store/README.md
@@ -1,0 +1,43 @@
+# Chrome Web Store listing assets
+
+Drop the assets the CWS submission form needs here. The listing copy that
+references these is in `docs/listing-copy.md`.
+
+## Required
+
+- **At least one screenshot** at exactly 1280x800 PNG, named
+  `screenshot-1.png`. CWS rejects submissions without one.
+
+## Recommended
+
+- **Up to five screenshots**, one per supported site is ideal:
+  `screenshot-1-claude.png`
+  `screenshot-2-gemini.png`
+  `screenshot-3-chatgpt.png`
+
+  All 1280x800 PNG. Show the Clio popup open over a real conversation
+  with the extract button visible — the reviewer needs to see what the
+  user sees.
+
+## Optional
+
+- **Promo tile** at 440x280 PNG named `promo-tile.png`. Only matters
+  for featured-listing eligibility. Skip for v1.0.
+
+## How to capture a screenshot
+
+1. Load Clio in Chrome: `chrome://extensions` → enable Developer mode
+   → "Load unpacked" → select `extensions/` from this repo
+2. Open any conversation on claude.ai / gemini.google.com / chatgpt.com
+3. Click the Clio icon in the toolbar so the popup is visible
+4. Use Chrome DevTools → Cmd/Ctrl+Shift+P → "Capture full size
+   screenshot" — or a regular OS screenshot tool, cropped to 1280x800.
+5. Save as PNG to this directory.
+
+## What NOT to capture
+
+- Conversations with sensitive content. Use a throwaway or
+  Claude/ChatGPT canned-demo conversation.
+- Personally-identifiable information visible in the sidebar.
+- Other Chrome extensions visible in the toolbar that you don't want
+  attributed to the reviewer's first impression.

--- a/docs/listing-copy.md
+++ b/docs/listing-copy.md
@@ -1,0 +1,157 @@
+# Chrome Web Store Listing Copy — Clio
+
+This file is the canonical source for everything that gets pasted into the
+Chrome Web Store submission form. Each section maps to one CWS field.
+Edit here, then copy-paste at submission time so the listing matches what
+the repo says.
+
+---
+
+## Name
+
+```
+Clio
+```
+
+---
+
+## Short description
+
+*CWS limit: 132 characters. Current draft: 105 chars.*
+
+```
+Export Claude, Gemini, and ChatGPT conversations to JSON + images. One click, fully local, no telemetry.
+```
+
+---
+
+## Long description
+
+*CWS limit: 16,000 characters. Plain text, no HTML.*
+
+```
+Clio is a Chrome extension that exports your conversations with Claude, Gemini, and ChatGPT to structured JSON files — for archival, research, citation, or personal record-keeping.
+
+HOW IT WORKS
+
+1. Open any conversation on claude.ai, gemini.google.com, or chatgpt.com
+2. Click the Clio icon in your toolbar
+3. The conversation downloads as a ZIP containing structured JSON (every turn, role, model identifier where available) plus all the images you've sent or received in that conversation
+
+PRIVACY-FIRST BY DESIGN
+
+Clio processes everything locally in your browser. Your conversations are NEVER sent to a server, never uploaded, never analyzed by any third party, never used to train any model. There is no Clio account, no signup, no telemetry. The extension makes no network requests outside of fetching images already embedded in your conversation (from the LLM provider's own image hosts).
+
+WHAT GETS EXTRACTED
+
+- Every user message and assistant response, in order
+- Each turn's text content (preserving code blocks with language tags)
+- Embedded images (saved alongside the JSON in the ZIP)
+- Conversation title and ID
+- Model identifier where the site exposes it (e.g. gpt-4o, claude-opus-4-7, gemini-2.5-pro)
+- Thinking / reasoning content where applicable (Claude extended thinking, ChatGPT o-series reasoning labels)
+
+USE CASES
+
+- Personal archive of your LLM conversations across providers
+- Backup before clearing your conversation history
+- Feeding old conversations into your own tooling (RAG, search, fine-tuning datasets you control)
+- Citing specific exchanges in writing or research
+- Comparing how different models handled the same question
+
+SUPPORTED SITES
+
+- claude.ai — Anthropic Claude
+- gemini.google.com — Google Gemini
+- chatgpt.com — OpenAI ChatGPT
+
+WHAT CLIO IS NOT
+
+- Not a cloud backup service. Your conversations stay on your machine.
+- Not an automatic backup. You click the icon when you want to export.
+- Not a cross-conversation search tool (planned for a future version).
+- Not affiliated with Anthropic, Google, or OpenAI.
+
+OPEN SOURCE
+
+MIT licensed. Source code, issue tracker, and changelog at
+https://github.com/martymcenroe/Clio. Privacy policy at
+https://cliocast.com/privacy.
+```
+
+---
+
+## Category
+
+```
+Productivity
+```
+
+---
+
+## Language
+
+```
+English (United States)
+```
+
+---
+
+## Permission justifications
+
+CWS requires a brief written justification for each declared permission and
+host permission. Paste these into the matching fields at submission time.
+
+### activeTab
+
+```
+Used to read the DOM of the currently active conversation tab when the user clicks the Clio icon. The extension does not access any other tab. activeTab is granted at click time and revoked when the user leaves the tab — Chrome enforces this scoping by design. This permission is the minimum required for the extension's stated function (one-click conversation export).
+```
+
+### downloads
+
+```
+Used to save the extracted conversation as a ZIP file to the user's computer. The ZIP is created entirely in the browser (via JSZip, bundled in the extension) and saved through Chrome's standard download flow to whatever folder the user has configured. No external upload, no server involvement.
+```
+
+### Host permissions: `https://claude.ai/*`, `https://gemini.google.com/*`, `https://chatgpt.com/*`
+
+```
+The content script must be allowed to run on these three AI chat sites in order to read the conversation DOM and extract message content. The script does not run on any other site. These three hosts are the entirety of the extension's web-surface — Clio has no business logic, fetches no analytics, and makes no requests outside the user's already-loaded conversation.
+```
+
+---
+
+## Privacy policy URL
+
+```
+https://cliocast.com/privacy
+```
+
+---
+
+## Single-purpose description
+
+*CWS asks: "Describe the single purpose of your extension."*
+
+```
+Export the user's own conversations with Claude, Gemini, and ChatGPT to a structured JSON file (plus any embedded images) on a single click, with no server-side component.
+```
+
+---
+
+## Support / contact email
+
+```
+cto@thrivetech.ai
+```
+
+*(Matches what runbook 30002 already documents as the publisher contact.)*
+
+---
+
+## Notes for the submitter (not pasted to CWS)
+
+- Screenshots: see `docs/assets/store/` — must have at least one at 1280x800 PNG. Recommend one screenshot per supported site (3 total) for the listing carousel.
+- Promo tile (440x280 PNG): optional. Skip unless we want to be eligible for featured-listing slots.
+- If the CWS review team asks for clarification on the privacy claims, the relevant evidence is: (a) zero `fetch()` / `XMLHttpRequest` calls in `extensions/src/` outside of `findImages` (which fetches images embedded in the conversation), (b) no analytics SDKs in `package.json`, (c) `host_permissions` scoped to the three target sites only.


### PR DESCRIPTION
## Summary

Drafts the Chrome Web Store listing copy that gets pasted into the submission form when we ship v1.4.0. Two files:

- `docs/listing-copy.md` — canonical source for every field in the CWS form (name, short/long descriptions, permission justifications, single-purpose statement, privacy URL, support email). Format is copy-paste friendly — each section maps to one CWS field.
- `docs/assets/store/README.md` — explains what screenshots/tiles still need to be added before submission. Operator-only work; agents can't capture screenshots of the live extension in the user's authenticated browser.

Short description: 105/132 chars. Long description ~2k chars / 16k limit. All permission justifications use the activeTab/downloads/host-permissions Clio actually declares — no overclaim, no aspirational features.

## Test plan

- [x] Spell check / sanity read
- [x] Privacy URL matches the live CFP deploy (cliocast.com/privacy — verified earlier today)
- [x] No mention of unshipped features (cross-conversation search correctly listed under "What Clio is NOT")

## Why not Closes #92

Issue #92's acceptance requires at least one 1280x800 screenshot in `docs/assets/store/`. That's operator work — capturing the extension running on a real conversation in the operator's authenticated browser. Once that screenshot lands, #92 can close. This PR moves the textual half of #92 across the line.

Refs #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)