### PR TITLE
security(privacy): swap personal gmail + add GDPR statement (#125, #126)

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-**Last updated:** 2026-05-22
+**Last updated:** 2026-05-23
 
 ## Summary
 
@@ -63,6 +63,16 @@ Because all data lives only on your local disk, your data subject rights are exe
 
 The conversations themselves remain on the LLM provider's servers under their own privacy terms — Clio does not change anything about Google's, Anthropic's, or OpenAI's data handling. Clio gives you a local copy; it does not remove the original.
 
+## GDPR / UK GDPR
+
+If you are in the EU, UK, or other jurisdictions covered by GDPR-equivalent laws, you have the right to access, correct, delete, restrict, or object to processing of your personal data, and the right to data portability.
+
+Clio holds no personal data. Your conversations and the ZIP files Clio writes live only on your own device, never on any Clio-controlled server. Those rights are therefore fulfilled by default — you control the files via your operating system, and there is nothing on a Clio server to access, export, or delete.
+
+If you still wish to make a formal data subject request (for example, to confirm we hold no data about you), email **opensource@martymcenroe.ai** with subject `Clio GDPR request`. We will respond within 30 days.
+
+We are not a "data controller" or "data processor" in the GDPR sense for any personal data, because the extension's architecture makes such processing impossible.
+
 ## Children's privacy
 
 Clio does not knowingly collect any data from anyone, including children. If you believe a child has been harmed by Clio's behavior, please contact us at the email below — but note that Clio runs locally and does not store or transmit data.
@@ -73,6 +83,6 @@ If this policy changes materially, the change will be reflected in a new "Last u
 
 ## Contact
 
-Privacy questions: **martymcenroe@gmail.com** (subject: `Clio privacy question`)
+Privacy questions: **opensource@martymcenroe.ai** (subject: `Clio privacy question`)
 
 Security vulnerabilities should be reported per [SECURITY.md](SECURITY.md), not as privacy questions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Clio is a Chrome extension that extracts your Gemini, Claude, and ChatGPT conver
 
 If you believe you have found a security vulnerability in Clio, please report it privately to:
 
-**martymcenroe@gmail.com** (subject line: `Clio security report`)
+**opensource@martymcenroe.ai** (subject line: `Clio security report`)
 
 Please **do not** file a public GitHub issue for security reports. The `Report a vulnerability` link routed from the issue templates points here.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -198,7 +198,7 @@
 
 <section>
   <h2>Contact</h2>
-  <p>Privacy questions or feedback: <a href="mailto:martymcenroe@gmail.com?subject=Clio%20privacy%20question">martymcenroe@gmail.com</a>.</p>
+  <p>Privacy questions or feedback: <a href="mailto:opensource@martymcenroe.ai?subject=Clio%20privacy%20question">opensource@martymcenroe.ai</a>.</p>
   <p>Security vulnerabilities: see <a href="https://github.com/martymcenroe/Clio/blob/main/SECURITY.md">SECURITY.md</a> for the private reporting channel. Do not file public issues for security reports.</p>
 </section>
 

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -112,7 +112,7 @@
 
 <header>
   <h1>Privacy Policy</h1>
-  <p class="last-updated">Last updated: 2026-05-22</p>
+  <p class="last-updated">Last updated: 2026-05-23</p>
 </header>
 
 <div class="summary">
@@ -196,6 +196,16 @@
 
 <p>The conversations themselves remain on the LLM provider's servers under their own privacy terms — Clio does not change anything about Google's, Anthropic's, or OpenAI's data handling. Clio gives you a local copy; it does not remove the original.</p>
 
+<h2>GDPR / UK GDPR</h2>
+
+<p>If you are in the EU, UK, or other jurisdictions covered by GDPR-equivalent laws, you have the right to access, correct, delete, restrict, or object to processing of your personal data, and the right to data portability.</p>
+
+<p>Clio holds no personal data. Your conversations and the ZIP files Clio writes live only on your own device, never on any Clio-controlled server. Those rights are therefore fulfilled by default — you control the files via your operating system, and there is nothing on a Clio server to access, export, or delete.</p>
+
+<p>If you still wish to make a formal data subject request (for example, to confirm we hold no data about you), email <strong>opensource@martymcenroe.ai</strong> with subject <code>Clio GDPR request</code>. We will respond within 30 days.</p>
+
+<p>We are not a "data controller" or "data processor" in the GDPR sense for any personal data, because the extension's architecture makes such processing impossible.</p>
+
 <h2>Children's privacy</h2>
 
 <p>Clio does not knowingly collect any data from anyone, including children. If you believe a child has been harmed by Clio's behavior, please contact us at the email below — but note that Clio runs locally and does not store or transmit data.</p>
@@ -206,7 +216,7 @@
 
 <h2>Contact</h2>
 
-<p>Privacy questions: <strong>martymcenroe@gmail.com</strong> (subject: <code>Clio privacy question</code>)</p>
+<p>Privacy questions: <strong>opensource@martymcenroe.ai</strong> (subject: <code>Clio privacy question</code>)</p>
 
 <p>Security vulnerabilities should be reported per <a href="https://github.com/martymcenroe/Clio/blob/main/SECURITY.md">SECURITY.md</a>, not as privacy questions.</p>
 


### PR DESCRIPTION
## Summary

Two related privacy-policy fixes that need to land together before CWS submission scrapes the privacy URL.

**#125 — gmail leak.** `martymcenroe@gmail.com` was in 4 tracked files, two of which serve from the LIVE cliocast.com domain that the CWS submission will declare as the privacy URL. Replaced with `opensource@martymcenroe.ai` (verified MX on Cloudflare). `cto@thrivetech.ai` used elsewhere for CWS publisher account stays.

**#126 — GDPR.** Added a simple GDPR / UK GDPR section to both PRIVACY.md and docs/privacy.html. Plain English: Clio holds no personal data, so subject rights are satisfied by default; contact `opensource@martymcenroe.ai` for any formal request.

## Files changed

- `PRIVACY.md` — email swap + GDPR section + Last-updated bumped to 2026-05-23
- `SECURITY.md` — email swap
- `docs/privacy.html` — email swap + GDPR section + Last-updated bumped
- `docs/index.html` — email swap in mailto link + visible address

## Test plan

- [x] `grep -rnE 'martymcenroe@gmail\.com'` across tracked files returns zero matches
- [x] `grep -rnE 'opensource@martymcenroe\.ai'` matches in 6 expected locations
- [ ] Post-merge: `python tools/build_site.py && wrangler pages deploy dist/site --project-name=clio --commit-dirty=true` — redeploys cliocast.com so the live privacy policy reflects the change

Closes #125
Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)