### PR TITLE
docs(privacy): drop unnecessary contact invitations from GDPR + Children's sections (#128, #129)

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -65,17 +65,15 @@ The conversations themselves remain on the LLM provider's servers under their ow
 
 ## GDPR / UK GDPR
 
-If you are in the EU, UK, or other jurisdictions covered by GDPR-equivalent laws, you have the right to access, correct, delete, restrict, or object to processing of your personal data, and the right to data portability.
+Clio does not process personal data. Your conversations and the ZIP files Clio writes live only on your own device — there is no Clio server, no Clio database, nothing that holds personal data about you.
 
-Clio holds no personal data. Your conversations and the ZIP files Clio writes live only on your own device, never on any Clio-controlled server. Those rights are therefore fulfilled by default — you control the files via your operating system, and there is nothing on a Clio server to access, export, or delete.
+If you are in the EU, UK, or other jurisdiction covered by GDPR-equivalent law, your subject rights (access, deletion, portability, etc.) are satisfied by default: there is nothing on a Clio server to access or delete. You control your local files via your operating system.
 
-If you still wish to make a formal data subject request (for example, to confirm we hold no data about you), email **opensource@martymcenroe.ai** with subject `Clio GDPR request`. We will respond within 30 days.
-
-We are not a "data controller" or "data processor" in the GDPR sense for any personal data, because the extension's architecture makes such processing impossible.
+The operator is the publisher of the software, not a "data controller" or "data processor" under GDPR for any personal data the extension touches. The architecture makes such processing impossible.
 
 ## Children's privacy
 
-Clio does not knowingly collect any data from anyone, including children. If you believe a child has been harmed by Clio's behavior, please contact us at the email below — but note that Clio runs locally and does not store or transmit data.
+Clio does not collect data from anyone, including children. COPPA, GDPR-K, and similar children's-privacy regimes regulate the **collection** of personal information from children — Clio's local-only design forecloses such collection. The extension has no remote endpoint, no telemetry, and no targeting; there is no behavior directed at any party other than the local user.
 
 ## Changes to this policy
 

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -198,17 +198,15 @@
 
 <h2>GDPR / UK GDPR</h2>
 
-<p>If you are in the EU, UK, or other jurisdictions covered by GDPR-equivalent laws, you have the right to access, correct, delete, restrict, or object to processing of your personal data, and the right to data portability.</p>
+<p>Clio does not process personal data. Your conversations and the ZIP files Clio writes live only on your own device — there is no Clio server, no Clio database, nothing that holds personal data about you.</p>
 
-<p>Clio holds no personal data. Your conversations and the ZIP files Clio writes live only on your own device, never on any Clio-controlled server. Those rights are therefore fulfilled by default — you control the files via your operating system, and there is nothing on a Clio server to access, export, or delete.</p>
+<p>If you are in the EU, UK, or other jurisdiction covered by GDPR-equivalent law, your subject rights (access, deletion, portability, etc.) are satisfied by default: there is nothing on a Clio server to access or delete. You control your local files via your operating system.</p>
 
-<p>If you still wish to make a formal data subject request (for example, to confirm we hold no data about you), email <strong>opensource@martymcenroe.ai</strong> with subject <code>Clio GDPR request</code>. We will respond within 30 days.</p>
-
-<p>We are not a "data controller" or "data processor" in the GDPR sense for any personal data, because the extension's architecture makes such processing impossible.</p>
+<p>The operator is the publisher of the software, not a "data controller" or "data processor" under GDPR for any personal data the extension touches. The architecture makes such processing impossible.</p>
 
 <h2>Children's privacy</h2>
 
-<p>Clio does not knowingly collect any data from anyone, including children. If you believe a child has been harmed by Clio's behavior, please contact us at the email below — but note that Clio runs locally and does not store or transmit data.</p>
+<p>Clio does not collect data from anyone, including children. COPPA, GDPR-K, and similar children's-privacy regimes regulate the <strong>collection</strong> of personal information from children — Clio's local-only design forecloses such collection. The extension has no remote endpoint, no telemetry, and no targeting; there is no behavior directed at any party other than the local user.</p>
 
 <h2>Changes to this policy</h2>
 


### PR DESCRIPTION
## Summary

Two paragraphs added in PR #127 create voluntary obligations against scenarios the extension's architecture forecloses. Both removed:

**#128 — GDPR.** Dropped the "email us, 30-day response" data-subject-request invitation. Clio doesn't process personal data → operator isn't a controller → subject rights have no party to be exercised against. A 30-day promise would create an obligation independent of GDPR and weakens the "not a controller" claim.

**#129 — Children's privacy.** Dropped the "if a child has been harmed by Clio's behavior, contact us" line. COPPA / GDPR-K regulate **collection**. Clio collects nothing from anyone. The "harm via behavior" scenario can't occur because Clio has no behavior toward any party other than the local user.

Both sections rewritten to state their respective positions plainly and stop there. Users with real questions still have the `opensource@martymcenroe.ai` channel in the Contact section — voluntary, unscheduled, no commitment.

## Files

- `PRIVACY.md`
- `docs/privacy.html`

## Test plan

- [x] No "30 days" / "data subject request" / "if a child has been harmed" / equivalent text in either file
- [ ] Post-merge: rebuild dist/site + redeploy CFP so cliocast.com/privacy reflects the change

Closes #128
Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)