### PR TITLE
docs(privacy): rewrite GDPR + Children's sections in plainer voice (#131)

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -65,15 +65,15 @@ The conversations themselves remain on the LLM provider's servers under their ow
 
 ## GDPR / UK GDPR
 
-Clio does not process personal data. Your conversations and the ZIP files Clio writes live only on your own device — there is no Clio server, no Clio database, nothing that holds personal data about you.
+Clio does not process personal data. Your conversations and the ZIP files Clio creates live only on your device. There is no Clio server, no Clio database, no record on our side that holds anything about you.
 
-If you are in the EU, UK, or other jurisdiction covered by GDPR-equivalent law, your subject rights (access, deletion, portability, etc.) are satisfied by default: there is nothing on a Clio server to access or delete. You control your local files via your operating system.
+If you are in the EU, UK, or somewhere covered by similar law, your subject rights (access, deletion, portability, and so on) are met by default. There is nothing on our end to access or delete. You control your local files yourself, through your operating system.
 
-The operator is the publisher of the software, not a "data controller" or "data processor" under GDPR for any personal data the extension touches. The architecture makes such processing impossible.
+The author of Clio is the software's publisher, not a data controller or processor in the GDPR sense. The way the extension is built, data collection on our side is not possible.
 
 ## Children's privacy
 
-Clio does not collect data from anyone, including children. COPPA, GDPR-K, and similar children's-privacy regimes regulate the **collection** of personal information from children — Clio's local-only design forecloses such collection. The extension has no remote endpoint, no telemetry, and no targeting; there is no behavior directed at any party other than the local user.
+Clio does not collect data from anyone, including children. COPPA, GDPR-K, and similar laws are about collection of personal information from children. Since Clio is local-only and the extension never sends data anywhere, no such collection happens. There is no remote endpoint, no telemetry, and no advertising.
 
 ## Changes to this policy
 

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -198,15 +198,15 @@
 
 <h2>GDPR / UK GDPR</h2>
 
-<p>Clio does not process personal data. Your conversations and the ZIP files Clio writes live only on your own device — there is no Clio server, no Clio database, nothing that holds personal data about you.</p>
+<p>Clio does not process personal data. Your conversations and the ZIP files Clio creates live only on your device. There is no Clio server, no Clio database, no record on our side that holds anything about you.</p>
 
-<p>If you are in the EU, UK, or other jurisdiction covered by GDPR-equivalent law, your subject rights (access, deletion, portability, etc.) are satisfied by default: there is nothing on a Clio server to access or delete. You control your local files via your operating system.</p>
+<p>If you are in the EU, UK, or somewhere covered by similar law, your subject rights (access, deletion, portability, and so on) are met by default. There is nothing on our end to access or delete. You control your local files yourself, through your operating system.</p>
 
-<p>The operator is the publisher of the software, not a "data controller" or "data processor" under GDPR for any personal data the extension touches. The architecture makes such processing impossible.</p>
+<p>The author of Clio is the software's publisher, not a data controller or processor in the GDPR sense. The way the extension is built, data collection on our side is not possible.</p>
 
 <h2>Children's privacy</h2>
 
-<p>Clio does not collect data from anyone, including children. COPPA, GDPR-K, and similar children's-privacy regimes regulate the <strong>collection</strong> of personal information from children — Clio's local-only design forecloses such collection. The extension has no remote endpoint, no telemetry, and no targeting; there is no behavior directed at any party other than the local user.</p>
+<p>Clio does not collect data from anyone, including children. COPPA, GDPR-K, and similar laws are about collection of personal information from children. Since Clio is local-only and the extension never sends data anywhere, no such collection happens. There is no remote endpoint, no telemetry, and no advertising.</p>
 
 <h2>Changes to this policy</h2>
 


### PR DESCRIPTION
## Summary

Operator flagged the GDPR and Children's privacy sections (added in PRs #127, #130) as reading "drafted by language model" — em-dash clause joins plus formal-legal vocabulary ("forecloses such collection", "the architecture makes such processing impossible", "behavior directed at any party other than the local user", "personal data the extension touches").

That's an unforced trust-credibility hit on a privacy policy where readers are specifically scanning for human-sounding assurance. Substance was right, register was wrong. Rewriting both sections in the plainer voice the rest of the policy uses.

Other em-dashes elsewhere in the policy are pre-existing and read naturally (list-item descriptions, substantive joins). Not in scope.

## Test plan

- [x] `forecloses` does not appear anywhere in PRIVACY.md / docs/privacy.html
- [x] Substantive content unchanged (no-processing, no-collection, not-a-controller positions all still stated)
- [ ] Post-merge: redeploy CFP so cliocast.com/privacy reflects the change

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)