### PR TITLE
docs(privacy): footer link to wiki, not main repo (#135)

### DIFF
--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -226,7 +226,7 @@
 <p>For security vulnerabilities, please follow the steps in <a href="https://github.com/martymcenroe/Clio/blob/main/SECURITY.md">SECURITY.md</a> instead.</p>
 
 <footer>
-  <p><a href="https://github.com/martymcenroe/Clio">Clio on GitHub</a> &middot; MIT License &middot; Copyright &copy; 2026 Martin McEnroe / THRIVETECH.AI</p>
+  <p><a href="https://github.com/martymcenroe/Clio/wiki">Clio wiki</a> &middot; MIT License &middot; Copyright &copy; 2026 Martin McEnroe / THRIVETECH.AI</p>
 </footer>
 
 </div>


### PR DESCRIPTION
## Summary

One-line footer update in `docs/privacy.html`. Footer link target now points to the wiki and the link text matches (`Clio wiki` instead of `Clio on GitHub`). The wiki is the more appropriate landing for someone who has just read the privacy policy and wants more context on governance / design.

## Test plan

- [x] Single line diff, no functional risk
- [ ] Post-merge: redeploy CFP

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)