### PR TITLE
fix(popup): move in-page progress badge to bottom-right (#140)

### DIFF
--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Clio",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Extract full Gemini, Claude, and ChatGPT conversations to JSON with images",
   "permissions": [
     "activeTab",

--- a/extensions/src/content.js
+++ b/extensions/src/content.js
@@ -71,7 +71,7 @@ function showProgress(message) {
     progressElement.id = 'clio-progress';
     progressElement.style.cssText = `
       position: fixed;
-      top: 20px;
+      bottom: 20px;
       right: 20px;
       background: #1a73e8;
       color: white;


### PR DESCRIPTION
## Summary

Single-line CSS change in `content.js` `showProgress()`: badge position `top: 20px` → `bottom: 20px`. Same right-edge, same z-index, same colors, same content. The popup is fixed top-right under the toolbar icon, so moving the badge to the bottom keeps both visible during extraction with zero overlap.

manifest.json: 1.3.7 → 1.3.8 per versioning policy.

## Test plan

- [x] All 268 jest tests pass
- [ ] Post-merge smoke: load conversation, click extract, confirm badge appears bottom-right while popup is open top-right; both fully visible

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)