### PR TITLE
fix(popup): site-aware last-result restore (#138)

### DIFF
--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Clio",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Extract full Gemini, Claude, and ChatGPT conversations to JSON with images",
   "permissions": [
     "activeTab",

--- a/extensions/src/popup.js
+++ b/extensions/src/popup.js
@@ -56,8 +56,13 @@ function showResult(messageCount, images, errors, scrollInfo, isLastResult = fal
 
 /**
  * Save extraction results to localStorage for persistence.
+ * @param {Object} data - extraction result
+ * @param {string} site - site key (claude / chatgpt / gemini) where the
+ *   extraction happened, used by restoreLastResult to gate display on
+ *   site match. Without it, the cached card is shown only when no
+ *   current-site argument is supplied (test path).
  */
-function saveLastResult(data) {
+function saveLastResult(data, site) {
   try {
     const lastResult = {
       messageCount: data.metadata.messageCount,
@@ -65,6 +70,7 @@ function saveLastResult(data) {
       errorCount: data.metadata.extractionErrors.length,
       scrollInfo: data.metadata.scrollInfo,
       title: data.metadata.title,
+      site: site || null,
       timestamp: new Date().toISOString()
     };
     localStorage.setItem('clio_lastResult', JSON.stringify(lastResult));
@@ -75,26 +81,35 @@ function saveLastResult(data) {
 
 /**
  * Restore last extraction result from localStorage if available.
+ * Site-aware: when currentSite is provided, only restores if the cached
+ * extraction was from the same site. Prevents the popup from showing
+ * Gemini stats on a ChatGPT page (#138).
+ * @param {string} [currentSite] - site key of the active tab
+ *   (claude / chatgpt / gemini). If omitted, falls back to the legacy
+ *   non-site-aware behavior. Old caches without a `site` field are
+ *   always hidden when currentSite is provided.
  */
-function restoreLastResult() {
+function restoreLastResult(currentSite) {
   try {
     const saved = localStorage.getItem('clio_lastResult');
-    if (saved) {
-      const lastResult = JSON.parse(saved);
-      // Only show if less than 1 hour old
-      const age = Date.now() - new Date(lastResult.timestamp).getTime();
-      if (age < 60 * 60 * 1000) {
-        showResult(
-          lastResult.messageCount,
-          lastResult.imageCount,
-          lastResult.errorCount,
-          lastResult.scrollInfo,
-          true // isLastResult
-        );
-        setStatus(`Last: ${lastResult.title || 'Untitled'}`, 'info');
-        return true;
-      }
-    }
+    if (!saved) return false;
+    const lastResult = JSON.parse(saved);
+    // Only show if less than 1 hour old
+    const age = Date.now() - new Date(lastResult.timestamp).getTime();
+    if (age >= 60 * 60 * 1000) return false;
+    // Site-mismatch gate. If caller passed currentSite, require the
+    // cached extraction's site to match. Old caches (pre-#138) have no
+    // site field and are always hidden when a currentSite is provided.
+    if (currentSite && lastResult.site !== currentSite) return false;
+    showResult(
+      lastResult.messageCount,
+      lastResult.imageCount,
+      lastResult.errorCount,
+      lastResult.scrollInfo,
+      true // isLastResult
+    );
+    setStatus(`Last: ${lastResult.title || 'Untitled'}`, 'info');
+    return true;
   } catch (e) {
     // Ignore localStorage errors
   }
@@ -283,8 +298,10 @@ async function handleExtract() {
       data.metadata.scrollInfo
     );
 
-    // Save to localStorage for persistence (popup may close during download)
-    saveLastResult(data);
+    // Save to localStorage for persistence (popup may close during download).
+    // Pass site so the next popup-open on a different site doesn't surface
+    // these stats (#138).
+    saveLastResult(data, getSitePrefix(tab.url));
 
     // Check size
     const estimatedSize = estimateExportSize(images || []);
@@ -333,15 +350,16 @@ const extractBtn = document.getElementById('extractBtn');
 if (extractBtn) {
   extractBtn.addEventListener('click', handleExtract);
 
-  // Restore last extraction results if available (for when popup was closed during save)
-  restoreLastResult();
-
-  // Check if we're on a Gemini page on load
+  // Determine active tab's site, then restore the last extraction's
+  // stats ONLY if it was from the same site (#138). On an unsupported
+  // page, disable the button and skip the restore entirely.
   chrome.tabs.query({ active: true, currentWindow: true }, ([tab]) => {
     if (!tab || !tab.url || !isSupportedSite(tab.url)) {
       setStatus('Open a Gemini, Claude, or ChatGPT conversation to extract.', 'warning');
       setButtonState(false);
+      return;
     }
+    restoreLastResult(getSitePrefix(tab.url));
   });
 }
 

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -16,6 +16,8 @@ const {
   hideProgress,
   showResult,
   setButtonState,
+  saveLastResult,
+  restoreLastResult,
   createZip,
   downloadBlob,
   handleExtract
@@ -351,6 +353,108 @@ describe('setButtonState', () => {
     setButtonState(false, 'Processing...');
     const extractBtn = document.getElementById('extractBtn');
     expect(extractBtn.textContent).toBe('Processing...');
+  });
+});
+
+// ============================================================================
+// Last-result persistence (site-aware — #138)
+// ============================================================================
+
+describe('saveLastResult', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('persists site in the blob', () => {
+    const data = {
+      metadata: {
+        title: 'Some Claude Conversation',
+        messageCount: 10,
+        imageCount: 0,
+        extractionErrors: [],
+        scrollInfo: { messagesLoaded: 10, scrollAttempts: 2 }
+      }
+    };
+    saveLastResult(data, 'claude');
+    const saved = JSON.parse(localStorage.getItem('clio_lastResult'));
+    expect(saved.site).toBe('claude');
+    expect(saved.title).toBe('Some Claude Conversation');
+    expect(saved.messageCount).toBe(10);
+  });
+
+  test('stores site=null when caller omits site', () => {
+    const data = {
+      metadata: {
+        title: 'No site',
+        messageCount: 1,
+        imageCount: 0,
+        extractionErrors: [],
+        scrollInfo: null
+      }
+    };
+    saveLastResult(data);
+    const saved = JSON.parse(localStorage.getItem('clio_lastResult'));
+    expect(saved.site).toBeNull();
+  });
+});
+
+describe('restoreLastResult (site-aware)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  function seedCache(overrides) {
+    const blob = Object.assign({
+      messageCount: 10,
+      imageCount: 0,
+      errorCount: 0,
+      scrollInfo: null,
+      title: 'Cached Conversation',
+      site: 'claude',
+      timestamp: new Date().toISOString()
+    }, overrides);
+    localStorage.setItem('clio_lastResult', JSON.stringify(blob));
+  }
+
+  test('shows cached stats when currentSite matches', () => {
+    seedCache({ site: 'claude' });
+    const result = restoreLastResult('claude');
+    expect(result).toBe(true);
+  });
+
+  test('hides cached stats when currentSite differs', () => {
+    seedCache({ site: 'gemini', title: 'A Gemini chat' });
+    const result = restoreLastResult('chatgpt');
+    expect(result).toBe(false);
+  });
+
+  test('hides legacy cache (no site field) when currentSite is provided', () => {
+    seedCache({ site: undefined });
+    // Remove the explicit undefined property so it serializes without site
+    const blob = JSON.parse(localStorage.getItem('clio_lastResult'));
+    delete blob.site;
+    localStorage.setItem('clio_lastResult', JSON.stringify(blob));
+    const result = restoreLastResult('claude');
+    expect(result).toBe(false);
+  });
+
+  test('hides when cache is older than 1 hour even if site matches', () => {
+    const stale = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    seedCache({ site: 'claude', timestamp: stale });
+    const result = restoreLastResult('claude');
+    expect(result).toBe(false);
+  });
+
+  test('returns false when no cache exists', () => {
+    expect(restoreLastResult('claude')).toBe(false);
+  });
+
+  test('legacy: shows cached stats when currentSite is omitted', () => {
+    // Backward compat for callers that pre-date #138 — pass no
+    // currentSite, get the old non-site-aware behavior.
+    seedCache({ site: 'gemini' });
+    const result = restoreLastResult();
+    expect(result).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

The popup's last-extraction stats card was shown on any supported tab regardless of which site had produced the cached data — operator's smoke test caught a ChatGPT tab displaying "Last: Conversation with Gemini" + 27 errors from an unrelated previous Gemini extraction.

Fix: cache the site key alongside the stats, gate display on a site match against the active tab.

- `saveLastResult(data, site)` — now persists site (`getSitePrefix(tab.url)`) into the localStorage blob
- `restoreLastResult(currentSite)` — only renders the card when `cached.site === currentSite`. Legacy caches without a site field are hidden when currentSite is provided. Old no-arg call works too (backward compat path for tests).
- Popup init flow now queries the active tab first, then passes the site key into `restoreLastResult`. Unsupported tabs disable the button and skip restore entirely.

Manifest: 1.3.8 → 1.3.9 per versioning policy.

## Test plan

- [x] All 276 jest tests pass (was 268; added 7 new tests for the site-match / mismatch / legacy / stale / no-cache / no-arg cases)
- [ ] Post-merge smoke: extract on Gemini, navigate to ChatGPT, open popup, confirm no Gemini stats appear; then extract on ChatGPT, open popup again on ChatGPT, confirm ChatGPT stats DO appear

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)