### PR TITLE
fix(popup): auto-recover from 'Receiving end does not exist' (#139)

### DIFF
--- a/docs/listing-copy.md
+++ b/docs/listing-copy.md
@@ -114,6 +114,12 @@ Used to read the DOM of the currently active conversation tab when the user clic
 Used to save the extracted conversation as a ZIP file to the user's computer. The ZIP is created entirely in the browser (via JSZip, bundled in the extension) and saved through Chrome's standard download flow to whatever folder the user has configured. No external upload, no server involvement.
 ```
 
+### scripting
+
+```
+Used solely as a recovery path. When the user clicks Clio on a tab that was opened before Clio was installed or last reloaded, Chrome's content script hasn't been injected into that tab — clicking the extract button would otherwise fail with the raw error "Could not establish connection." The scripting permission lets Clio re-inject its own content script (the same files declared in the manifest's content_scripts entries) into the active tab so the extraction can proceed. It is invoked only on this specific failure path, only into the currently active tab, and only with Clio's own bundled scripts. It is not used to inject code into any other tab or at any other time.
+```
+
 ### Host permissions: `https://claude.ai/*`, `https://gemini.google.com/*`, `https://chatgpt.com/*`
 
 ```

--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -1,11 +1,12 @@
 {
   "manifest_version": 3,
   "name": "Clio",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "Extract full Gemini, Claude, and ChatGPT conversations to JSON with images",
   "permissions": [
     "activeTab",
-    "downloads"
+    "downloads",
+    "scripting"
   ],
   "host_permissions": [
     "https://gemini.google.com/*",

--- a/extensions/src/popup.js
+++ b/extensions/src/popup.js
@@ -247,6 +247,78 @@ function formatBytes(bytes) {
 }
 
 // ============================================================================
+// Content-script messaging with re-inject recovery (#139)
+// ============================================================================
+
+/**
+ * Pattern that matches the Chrome error raised when chrome.tabs.sendMessage
+ * targets a tab whose content script is not loaded. Two variant strings
+ * are seen in the wild depending on Chrome version.
+ */
+const RECEIVING_END_ERROR = /Receiving end does not exist|Could not establish connection/i;
+
+/**
+ * Map a site key to the [selectors-file, content.js] script paths to
+ * inject when recovering from a missing content script.
+ */
+function scriptsForSite(site) {
+  if (site === 'claude') return ['src/selectors-claude.js', 'src/content.js'];
+  if (site === 'chatgpt') return ['src/selectors-chatgpt.js', 'src/content.js'];
+  return ['src/selectors.js', 'src/content.js']; // gemini (default)
+}
+
+/**
+ * sendMessage wrapper that converts the Chrome callback-style API to a
+ * Promise. Resolves with the response or rejects with an Error whose
+ * message is chrome.runtime.lastError.message.
+ */
+function sendExtractMessageOnce(tabId) {
+  return new Promise((resolve, reject) => {
+    chrome.tabs.sendMessage(tabId, { action: 'extract' }, response => {
+      if (chrome.runtime.lastError) {
+        reject(new Error(chrome.runtime.lastError.message));
+      } else {
+        resolve(response);
+      }
+    });
+  });
+}
+
+/**
+ * Send the extract message to the active tab. If the content script is
+ * not loaded ("Receiving end does not exist" / "Could not establish
+ * connection"), inject it via chrome.scripting.executeScript and retry
+ * exactly once. Any other error bubbles up unchanged. After exhausting
+ * the retry, raises a user-friendly Error.
+ */
+async function sendExtractMessage(tab) {
+  try {
+    return await sendExtractMessageOnce(tab.id);
+  } catch (err) {
+    if (!RECEIVING_END_ERROR.test(err.message || '')) {
+      throw err; // unrelated extraction error — let it surface as-is
+    }
+    // Recovery path: re-inject the content script for this site.
+    if (!chrome.scripting || !chrome.scripting.executeScript) {
+      throw new Error("Couldn't reach the page. Please reload the tab and try again.");
+    }
+    try {
+      await chrome.scripting.executeScript({
+        target: { tabId: tab.id },
+        files: scriptsForSite(getSitePrefix(tab.url))
+      });
+    } catch (injectErr) {
+      throw new Error("Couldn't reach the page. Please reload the tab and try again.");
+    }
+    try {
+      return await sendExtractMessageOnce(tab.id);
+    } catch (retryErr) {
+      throw new Error("Couldn't reach the page. Please reload the tab and try again.");
+    }
+  }
+}
+
+// ============================================================================
 // Main Handler
 // ============================================================================
 
@@ -269,18 +341,15 @@ async function handleExtract() {
       return;
     }
 
-    // Send extract message to content script
+    // Send extract message to content script. If the content script
+    // isn't loaded in the tab (e.g. tab was opened before the extension
+    // was installed/reloaded), Chrome rejects with "Receiving end does
+    // not exist". sendExtractMessage transparently re-injects the
+    // content script and retries once before surfacing a friendly
+    // recovery message (#139).
     showProgress('Extracting conversation...');
 
-    const result = await new Promise((resolve, reject) => {
-      chrome.tabs.sendMessage(tab.id, { action: 'extract' }, response => {
-        if (chrome.runtime.lastError) {
-          reject(new Error(chrome.runtime.lastError.message));
-        } else {
-          resolve(response);
-        }
-      });
-    });
+    const result = await sendExtractMessage(tab);
 
     if (!result.success) {
       setStatus(result.error || 'Extraction failed', 'error');
@@ -383,6 +452,8 @@ if (typeof module !== 'undefined' && module.exports) {
     downloadBlob,
     handleExtract,
     saveLastResult,
-    restoreLastResult
+    restoreLastResult,
+    sendExtractMessage,
+    scriptsForSite
   };
 }

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -18,6 +18,8 @@ const {
   setButtonState,
   saveLastResult,
   restoreLastResult,
+  sendExtractMessage,
+  scriptsForSite,
   createZip,
   downloadBlob,
   handleExtract
@@ -455,6 +457,107 @@ describe('restoreLastResult (site-aware)', () => {
     seedCache({ site: 'gemini' });
     const result = restoreLastResult();
     expect(result).toBe(true);
+  });
+});
+
+// ============================================================================
+// Content-script messaging recovery (#139)
+// ============================================================================
+
+describe('scriptsForSite', () => {
+  test('claude site → claude selectors', () => {
+    expect(scriptsForSite('claude')).toEqual(['src/selectors-claude.js', 'src/content.js']);
+  });
+  test('chatgpt site → chatgpt selectors', () => {
+    expect(scriptsForSite('chatgpt')).toEqual(['src/selectors-chatgpt.js', 'src/content.js']);
+  });
+  test('gemini (or unknown) → default selectors', () => {
+    expect(scriptsForSite('gemini')).toEqual(['src/selectors.js', 'src/content.js']);
+    expect(scriptsForSite('unknown')).toEqual(['src/selectors.js', 'src/content.js']);
+  });
+});
+
+describe('sendExtractMessage (re-inject + retry)', () => {
+  const tab = { id: 42, url: 'https://claude.ai/chat/abc' };
+
+  test('happy path: first sendMessage succeeds, no re-inject', async () => {
+    chrome.tabs.sendMessage.mockImplementation((tabId, msg, cb) => {
+      cb({ success: true, data: { hello: 'world' } });
+    });
+    const result = await sendExtractMessage(tab);
+    expect(result.success).toBe(true);
+    expect(result.data.hello).toBe('world');
+    expect(chrome.scripting.executeScript).not.toHaveBeenCalled();
+  });
+
+  test('unrelated error: throws original error, no re-inject', async () => {
+    chrome.tabs.sendMessage.mockImplementation((tabId, msg, cb) => {
+      chrome.runtime.lastError = { message: 'Some other unrelated error' };
+      cb(null);
+      chrome.runtime.lastError = null;
+    });
+    await expect(sendExtractMessage(tab)).rejects.toThrow('Some other unrelated error');
+    expect(chrome.scripting.executeScript).not.toHaveBeenCalled();
+  });
+
+  test('receiving-end error → executeScript succeeds → retry succeeds', async () => {
+    let attempt = 0;
+    chrome.tabs.sendMessage.mockImplementation((tabId, msg, cb) => {
+      attempt++;
+      if (attempt === 1) {
+        chrome.runtime.lastError = { message: 'Could not establish connection. Receiving end does not exist.' };
+        cb(null);
+        chrome.runtime.lastError = null;
+      } else {
+        cb({ success: true, data: { recovered: true } });
+      }
+    });
+    chrome.scripting.executeScript.mockResolvedValue([]);
+
+    const result = await sendExtractMessage(tab);
+    expect(result.success).toBe(true);
+    expect(result.data.recovered).toBe(true);
+    expect(chrome.scripting.executeScript).toHaveBeenCalledTimes(1);
+    expect(chrome.scripting.executeScript).toHaveBeenCalledWith({
+      target: { tabId: 42 },
+      files: ['src/selectors-claude.js', 'src/content.js']
+    });
+    expect(attempt).toBe(2);
+  });
+
+  test('receiving-end error → executeScript fails → throws friendly error', async () => {
+    chrome.tabs.sendMessage.mockImplementation((tabId, msg, cb) => {
+      chrome.runtime.lastError = { message: 'Receiving end does not exist' };
+      cb(null);
+      chrome.runtime.lastError = null;
+    });
+    chrome.scripting.executeScript.mockRejectedValue(new Error('permission denied'));
+    await expect(sendExtractMessage(tab)).rejects.toThrow("Couldn't reach the page. Please reload the tab and try again.");
+  });
+
+  test('receiving-end error → executeScript ok → retry fails → throws friendly error', async () => {
+    chrome.tabs.sendMessage.mockImplementation((tabId, msg, cb) => {
+      chrome.runtime.lastError = { message: 'Receiving end does not exist' };
+      cb(null);
+      chrome.runtime.lastError = null;
+    });
+    chrome.scripting.executeScript.mockResolvedValue([]);
+    await expect(sendExtractMessage(tab)).rejects.toThrow("Couldn't reach the page. Please reload the tab and try again.");
+  });
+
+  test('receiving-end error + chrome.scripting absent → friendly error', async () => {
+    chrome.tabs.sendMessage.mockImplementation((tabId, msg, cb) => {
+      chrome.runtime.lastError = { message: 'Receiving end does not exist' };
+      cb(null);
+      chrome.runtime.lastError = null;
+    });
+    const savedScripting = chrome.scripting;
+    delete chrome.scripting;
+    try {
+      await expect(sendExtractMessage(tab)).rejects.toThrow("Couldn't reach the page. Please reload the tab and try again.");
+    } finally {
+      chrome.scripting = savedScripting;
+    }
   });
 });
 

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -21,6 +21,9 @@ global.chrome = {
     onChanged: {
       addListener: jest.fn()
     }
+  },
+  scripting: {
+    executeScript: jest.fn()
   }
 };
 
@@ -34,6 +37,7 @@ beforeEach(() => {
   chrome.tabs.sendMessage.mockClear();
   chrome.downloads.download.mockClear();
   chrome.downloads.onChanged.addListener.mockClear();
+  chrome.scripting.executeScript.mockClear();
 });
 
 // Mock JSZip for popup.js tests


### PR DESCRIPTION
## Summary

Chrome's raw error "Could not establish connection. Receiving end does not exist." was surfacing directly to the user whenever they clicked Clio on a tab that pre-dated the extension's install/reload. First-impression disaster for CWS users.

Fix:
- New `sendExtractMessage(tab)` helper in popup.js wraps the chrome.tabs.sendMessage call. On the receiving-end error specifically, re-injects the content script via `chrome.scripting.executeScript` and retries once. Unrelated errors bubble up unchanged. If the retry / inject path also fails, surfaces a friendly: "Couldn't reach the page. Please reload the tab and try again."
- `manifest.json` adds `"scripting"` to permissions (required for executeScript) and bumps 1.3.9 → 1.3.10
- `docs/listing-copy.md` adds the scripting permission justification — narrowly scoped to "only on the missing-content-script recovery path, only into the active tab, only with Clio's own bundled scripts"

## Test plan

- [x] All 285 jest tests pass (was 276; added 9 covering scriptsForSite + 6 sendExtractMessage code paths)
- [ ] Post-merge smoke: open Clio extension page, navigate to a Claude/Gemini/ChatGPT tab, click Clio → confirm auto-recovery (no raw Chrome error visible)

## Closes

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)