### PR TITLE
fix(gemini): host_permissions for googleusercontent.com + popup warning (#141)

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -37,7 +37,7 @@ Clio does not:
 - Include any analytics, advertising, or fingerprinting code
 - Load any code from the internet (everything Clio runs is bundled into the extension you install)
 
-You can verify all of this by reading the [extension's source code](https://github.com/martymcenroe/Clio). The extension makes no network requests outside of the three chat sites it supports (gemini.google.com, claude.ai, and chatgpt.com), and the only requests it sends to those sites are for the image files that already appear in the conversation you are viewing.
+You can verify all of this by reading the [extension's source code](https://github.com/martymcenroe/Clio). The extension makes network requests only to two kinds of place: (1) the three chat sites it supports (gemini.google.com, claude.ai, and chatgpt.com), to read the conversation you are viewing; and (2) the provider-controlled image-hosting domains where conversations' embedded images live (currently googleusercontent.com, where Gemini stores user-uploaded files). The only requests sent to those image hosts are to download images that already appear in the conversation you are viewing, so the ZIP contains them.
 
 ## What permissions Clio asks for, and why
 
@@ -48,6 +48,8 @@ The Chrome Web Store requires extensions to declare and justify every permission
 | `activeTab` | Read the conversation visible on the tab you are looking at, only at the moment you click the Clio button | To read the conversation you want to save |
 | `downloads` | Save the resulting ZIP file to your computer through Chrome's "Save As" window | To deliver the saved conversation to you |
 | `host_permissions` for `gemini.google.com`, `claude.ai`, and `chatgpt.com` | Run Clio's reading code only on those three chat sites | These are the only three sites Clio works on |
+| `host_permissions` for `googleusercontent.com` (and its subdomains) | Download user-uploaded images from Gemini conversations so they end up in the ZIP | Gemini hosts uploaded files on this domain; without permission, the browser would block the fetch and the images would be missing from your saved copy |
+| `scripting` | Re-inject Clio's own reading code into the active tab if it isn't already there | Recovery path only — used when you click Clio on a tab that was open before Clio was installed or last reloaded |
 
 Permissions Clio does **not** ask for: tabs, cookies, web requests, storage, identity, notifications, or access to any other websites.
 

--- a/docs/listing-copy.md
+++ b/docs/listing-copy.md
@@ -120,6 +120,12 @@ Used to save the extracted conversation as a ZIP file to the user's computer. Th
 Used solely as a recovery path. When the user clicks Clio on a tab that was opened before Clio was installed or last reloaded, Chrome's content script hasn't been injected into that tab — clicking the extract button would otherwise fail with the raw error "Could not establish connection." The scripting permission lets Clio re-inject its own content script (the same files declared in the manifest's content_scripts entries) into the active tab so the extraction can proceed. It is invoked only on this specific failure path, only into the currently active tab, and only with Clio's own bundled scripts. It is not used to inject code into any other tab or at any other time.
 ```
 
+### Host permissions: `https://*.googleusercontent.com/*`
+
+```
+Used to fetch user-uploaded image attachments from Gemini conversations. Gemini stores uploaded files at session-authenticated URLs on googleusercontent.com (e.g., lh3.googleusercontent.com). Without this host permission, the browser blocks the extension from fetching these images, leaving them missing from the ZIP. The extension only fetches images that are already embedded in the conversation the user is viewing — it does not read or modify any other content on these hosts. The wildcard covers the various lh3/lh4/lh5 subdomains Gemini may use depending on hash routing.
+```
+
 ### Host permissions: `https://claude.ai/*`, `https://gemini.google.com/*`, `https://chatgpt.com/*`
 
 ```

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -156,7 +156,7 @@
   <li>Load any code from the internet (everything Clio runs is bundled into the extension you install)</li>
 </ul>
 
-<p>You can verify all of this by reading the <a href="https://github.com/martymcenroe/Clio">extension&rsquo;s source code</a>. The extension makes no network requests outside of the three chat sites it supports (gemini.google.com, claude.ai, and chatgpt.com), and the only requests it sends to those sites are for the image files that already appear in the conversation you are viewing.</p>
+<p>You can verify all of this by reading the <a href="https://github.com/martymcenroe/Clio">extension&rsquo;s source code</a>. The extension makes network requests only to two kinds of place: (1) the three chat sites it supports (gemini.google.com, claude.ai, and chatgpt.com), to read the conversation you are viewing; and (2) the provider-controlled image-hosting domains where conversations&rsquo; embedded images live (currently googleusercontent.com, where Gemini stores user-uploaded files). The only requests sent to those image hosts are to download images that already appear in the conversation you are viewing, so the ZIP contains them.</p>
 
 <h2>What permissions Clio asks for, and why</h2>
 
@@ -185,6 +185,16 @@
       <td><code>host_permissions</code> for <code>gemini.google.com</code>, <code>claude.ai</code>, and <code>chatgpt.com</code></td>
       <td>Run Clio&rsquo;s reading code only on those three chat sites</td>
       <td>These are the only three sites Clio works on</td>
+    </tr>
+    <tr>
+      <td><code>host_permissions</code> for <code>googleusercontent.com</code> (and subdomains)</td>
+      <td>Download user-uploaded images from Gemini conversations so they end up in the ZIP</td>
+      <td>Gemini hosts uploaded files on this domain; without permission, the browser would block the fetch and the images would be missing from your saved copy</td>
+    </tr>
+    <tr>
+      <td><code>scripting</code></td>
+      <td>Re-inject Clio&rsquo;s own reading code into the active tab if it isn&rsquo;t already there</td>
+      <td>Recovery path only &mdash; used when you click Clio on a tab that was open before Clio was installed or last reloaded</td>
     </tr>
   </tbody>
 </table>

--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Clio",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "description": "Extract full Gemini, Claude, and ChatGPT conversations to JSON with images",
   "permissions": [
     "activeTab",
@@ -11,7 +11,8 @@
   "host_permissions": [
     "https://gemini.google.com/*",
     "https://claude.ai/*",
-    "https://chatgpt.com/*"
+    "https://chatgpt.com/*",
+    "https://*.googleusercontent.com/*"
   ],
   "action": {
     "default_popup": "src/popup.html",

--- a/extensions/src/popup.html
+++ b/extensions/src/popup.html
@@ -212,6 +212,10 @@
     </div>
   </div>
 
+  <div id="imageFetchWarning" class="status warning" style="display: none; margin-top: 12px;">
+    <span id="imageFetchWarningText"></span>
+  </div>
+
   <div class="footer">
     Local processing only. No data sent to servers.
   </div>

--- a/extensions/src/popup.js
+++ b/extensions/src/popup.js
@@ -29,6 +29,30 @@ function hideProgress() {
   progressEl.classList.remove('visible');
 }
 
+/**
+ * Show a warning row when some images failed to fetch (typically due to
+ * the provider's image-CDN not returning CORS headers permitting the
+ * extension's fetch). Hides the row when failedCount is 0. The popup
+ * still completes — the conversation text is unaffected — but the user
+ * needs to know images are missing (#141).
+ * @param {number} failedCount
+ */
+function showImageFetchWarning(failedCount) {
+  const el = document.getElementById('imageFetchWarning');
+  if (!el) return;
+  const text = document.getElementById('imageFetchWarningText');
+  if (failedCount > 0) {
+    if (text) {
+      text.textContent = failedCount === 1
+        ? '1 image could not be saved (provider blocked the download). See conversation.json metadata.extractionErrors for details.'
+        : `${failedCount} images could not be saved (provider blocked the download). See conversation.json metadata.extractionErrors for details.`;
+    }
+    el.style.display = 'block';
+  } else {
+    el.style.display = 'none';
+  }
+}
+
 function showResult(messageCount, images, errors, scrollInfo, isLastResult = false) {
   const resultEl = document.getElementById('result');
   resultEl.classList.add('visible');
@@ -367,6 +391,14 @@ async function handleExtract() {
       data.metadata.scrollInfo
     );
 
+    // Surface image-fetch failures explicitly (the bare error count
+    // doesn't communicate what kind of failure it was). Counts only
+    // image_fetch type errors — other extraction warnings appear via
+    // the warnings array below (#141).
+    const imageFetchFailures = (data.metadata.extractionErrors || [])
+      .filter(e => e && e.type === 'image_fetch').length;
+    showImageFetchWarning(imageFetchFailures);
+
     // Save to localStorage for persistence (popup may close during download).
     // Pass site so the next popup-open on a different site doesn't surface
     // these stats (#138).
@@ -447,6 +479,7 @@ if (typeof module !== 'undefined' && module.exports) {
     showProgress,
     hideProgress,
     showResult,
+    showImageFetchWarning,
     setButtonState,
     createZip,
     downloadBlob,

--- a/tests/fixtures/popup.html
+++ b/tests/fixtures/popup.html
@@ -28,3 +28,7 @@
     <span id="errorCount">-</span>
   </div>
 </div>
+
+<div id="imageFetchWarning" style="display: none;">
+  <span id="imageFetchWarningText"></span>
+</div>

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -15,6 +15,7 @@ const {
   showProgress,
   hideProgress,
   showResult,
+  showImageFetchWarning,
   setButtonState,
   saveLastResult,
   restoreLastResult,
@@ -355,6 +356,43 @@ describe('setButtonState', () => {
     setButtonState(false, 'Processing...');
     const extractBtn = document.getElementById('extractBtn');
     expect(extractBtn.textContent).toBe('Processing...');
+  });
+});
+
+// ============================================================================
+// Image-fetch warning surface (#141)
+// ============================================================================
+
+describe('showImageFetchWarning', () => {
+  test('hides the warning when failedCount is 0', () => {
+    const el = document.getElementById('imageFetchWarning');
+    el.style.display = 'block';
+    showImageFetchWarning(0);
+    expect(el.style.display).toBe('none');
+  });
+
+  test('shows warning with singular text when failedCount is 1', () => {
+    showImageFetchWarning(1);
+    const el = document.getElementById('imageFetchWarning');
+    const text = document.getElementById('imageFetchWarningText');
+    expect(el.style.display).toBe('block');
+    expect(text.textContent).toMatch(/^1 image could not be saved/);
+  });
+
+  test('shows warning with plural text when failedCount > 1', () => {
+    showImageFetchWarning(27);
+    const el = document.getElementById('imageFetchWarning');
+    const text = document.getElementById('imageFetchWarningText');
+    expect(el.style.display).toBe('block');
+    expect(text.textContent).toMatch(/^27 images could not be saved/);
+  });
+
+  test('hides when failedCount transitions back to 0 after being non-zero', () => {
+    showImageFetchWarning(5);
+    const el = document.getElementById('imageFetchWarning');
+    expect(el.style.display).toBe('block');
+    showImageFetchWarning(0);
+    expect(el.style.display).toBe('none');
   });
 });
 


### PR DESCRIPTION
## Summary

Gemini image fetches were failing 100% — every user-uploaded image returned "Failed to fetch" due to CORS, leaving ZIPs with empty `images/` folders and the failure silent unless the user inspected `metadata.extractionErrors`. Operator chose the actually-fix-it approach over warn-only.

Two-part fix:

**1. host_permissions** — adds `https://*.googleusercontent.com/*` to manifest. Chrome treats the extension's fetch as same-origin for that host and skips CORS. Gemini's uploaded images now actually land in the ZIP. Wildcard covers `lh3` / `lh4` / `lh5` (Gemini routes by hash).

**2. Popup warning** — new `showImageFetchWarning()` in popup.js + `#imageFetchWarning` element in popup.html. After every extraction, handleExtract counts image_fetch failures from extractionErrors and surfaces a yellow warning row when count > 0. Catches any remaining image-host failures (Claude / ChatGPT CDNs — future PRs when we have evidence of their hostnames).

**Privacy / listing updates:**
- `PRIVACY.md` "Where the data goes" updated (brief, per operator directive): adds second category of network destination (provider image hosts, currently googleusercontent.com). Permission table gets two new rows.
- `docs/privacy.html` mirrors PRIVACY.md. CFP redeploy required post-merge.
- `docs/listing-copy.md`: justification for the new host_permissions entry.

## Test plan

- [x] All 289 jest tests pass (was 285; added 4 for showImageFetchWarning)
- [ ] Post-merge: rebuild dist/site + redeploy CFP so cliocast.com/privacy reflects new disclosure before CWS scrapes
- [ ] Post-merge smoke: extract a Gemini conversation with uploaded images; confirm `images/` folder contains the bytes and the popup does NOT show the warning row

## Future follow-ups (separate issues / PRs)

When operator extracts a conversation with images on Claude or ChatGPT and the popup warning surfaces, the originalSrc URL in metadata.extractionErrors will identify those providers' image hosts. A small follow-up PR adds those hosts to host_permissions + an update to the privacy disclosure.

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)