### PR TITLE
chore(background): strip pre-submission console.log breadcrumbs (Closes #151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [1.4.1] — 2026-05-25
+
+Pre-submission cleanup release. `v1.4.0` was tagged but never submitted to the Chrome Web Store — pre-flight surfaced two unnecessary `console.log` calls in the background service worker. They do not violate the privacy policy (local console output, never transmitted), but they present a confusing surface for a reviewer auditing a strict-local extension. `v1.4.1` ships without them.
+
+### Removed
+- `console.log` for the `chrome.runtime.onInstalled` install/update event (#151)
+- `console.log` for the `chrome.downloads.onChanged` completion event (#151)
+
+### Changed
+- Background-service-worker listener bodies reduced to no-op stubs after the debug logs were removed; listener registrations remain because the manifest declares them (#151)
+- `tests/background.test.js` updated to assert the handlers stay silent rather than asserting log output (#151)
+
 ## [1.4.0] — 2026-05-24
 
-The Chrome Web Store launch release.
+The Chrome Web Store launch release. **Tagged but never submitted** — superseded by 1.4.1.
 
 ### Added
 - Repository hygiene: `LICENSE`, `CONTRIBUTING.md`, `SECURITY.md`, `CHANGELOG.md`, GitHub issue and PR templates

--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Clio",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Extract full Gemini, Claude, and ChatGPT conversations to JSON with images",
   "permissions": [
     "activeTab",

--- a/extensions/src/background.js
+++ b/extensions/src/background.js
@@ -7,17 +7,11 @@
 
 /* global chrome */
 
-// Log extension installation/update
-chrome.runtime.onInstalled.addListener((details) => {
-  console.log('Clio installed/updated:', details.reason);
-});
-
-// Handle download completion notifications (optional)
-chrome.downloads.onChanged.addListener((delta) => {
-  if (delta.state && delta.state.current === 'complete') {
-    console.log('Download completed:', delta.id);
-  }
-});
+// Listener stubs. Required by the manifest's background.service_worker
+// declaration. No-op after #151 removed the debug console.log breadcrumbs
+// that previously lived in these bodies.
+chrome.runtime.onInstalled.addListener(() => {});
+chrome.downloads.onChanged.addListener(() => {});
 
 // ============================================================================
 // Exports for Testing

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1,7 +1,10 @@
 /**
  * Unit tests for background.js (service worker)
  *
- * Tests Chrome event listener registration and handler behavior.
+ * Tests Chrome event listener registration. The console.log behavior these
+ * tests previously asserted was removed in #151 to keep the source clean
+ * for the Chrome Web Store reviewer; the listener registrations remain as
+ * no-op stubs because the manifest declares them.
  */
 
 describe('background.js', () => {
@@ -10,17 +13,13 @@ describe('background.js', () => {
   let consoleLogSpy;
 
   beforeEach(() => {
-    // Clear mocks
     chrome.runtime.onInstalled.addListener.mockClear();
     chrome.downloads.onChanged.addListener.mockClear();
 
-    // Spy on console.log
     consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
 
-    // Reset module cache to re-run registration
     jest.resetModules();
 
-    // Capture the callbacks when background.js is loaded
     chrome.runtime.onInstalled.addListener.mockImplementation((cb) => {
       onInstalledCallback = cb;
     });
@@ -28,7 +27,6 @@ describe('background.js', () => {
       onChangedCallback = cb;
     });
 
-    // Load the module
     require('../extensions/src/background.js');
   });
 
@@ -48,49 +46,17 @@ describe('background.js', () => {
     });
   });
 
-  describe('onInstalled Handler', () => {
-    test('logs install event', () => {
+  describe('Handlers are silent (no debug logging)', () => {
+    test('onInstalled handler does not call console.log', () => {
       onInstalledCallback({ reason: 'install' });
-      expect(consoleLogSpy).toHaveBeenCalledWith('Clio installed/updated:', 'install');
-    });
-
-    test('logs update event', () => {
       onInstalledCallback({ reason: 'update' });
-      expect(consoleLogSpy).toHaveBeenCalledWith('Clio installed/updated:', 'update');
-    });
-
-    test('logs browser_update event', () => {
       onInstalledCallback({ reason: 'browser_update' });
-      expect(consoleLogSpy).toHaveBeenCalledWith('Clio installed/updated:', 'browser_update');
-    });
-  });
-
-  describe('onChanged Handler', () => {
-    test('logs when download completes', () => {
-      onChangedCallback({
-        id: 123,
-        state: { current: 'complete' }
-      });
-      expect(consoleLogSpy).toHaveBeenCalledWith('Download completed:', 123);
-    });
-
-    test('does not log when download is in progress', () => {
-      onChangedCallback({
-        id: 123,
-        state: { current: 'in_progress' }
-      });
       expect(consoleLogSpy).not.toHaveBeenCalled();
     });
 
-    test('does not log when state is not provided', () => {
-      onChangedCallback({
-        id: 123,
-        filename: { current: 'test.zip' }
-      });
-      expect(consoleLogSpy).not.toHaveBeenCalled();
-    });
-
-    test('does not log when delta has no state property', () => {
+    test('onChanged handler does not call console.log', () => {
+      onChangedCallback({ id: 123, state: { current: 'complete' } });
+      onChangedCallback({ id: 123, state: { current: 'in_progress' } });
       onChangedCallback({ id: 123 });
       expect(consoleLogSpy).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary

Pre-flight before CWS submission surfaced two `console.log` calls in `extensions/src/background.js`:

- `console.log('Clio installed/updated:', details.reason);` on install/update
- `console.log('Download completed:', delta.id);` on download completion

They do **not** violate the privacy policy — local console output, never transmitted, content was an install-reason string and Chrome's internal download ID. But they present an unnecessary surface for a CWS reviewer auditing a strict-local extension.

This PR removes both log lines, reduces the listener bodies to no-op stubs (only thing left after the logs went), and updates `tests/background.test.js` to assert the handlers stay silent rather than assert log output.

Bump manifest 1.4.0 → 1.4.1. v1.4.0 was tagged but never submitted to CWS — 1.4.1 supersedes it as the launch artifact.

## Test plan

- [x] All 284 jest tests pass (was 289 — 5 log-assertion tests replaced by 2 silence tests, net -3 + -2 from the redundant cases collapsed)
- [x] No new lint errors (no `npm run lint` script defined; verified manually)
- [ ] `python tools/build_release.py` produces `dist/clio-chrome-v1.4.1.zip` after merge
- [ ] Operator uploads via runbook 30002 (tracked in #95)

Closes #151