### PR TITLE
chore: fix CLAUDE.md drift -- align with ADR 0219 (M9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,17 +1,17 @@
 # CLAUDE.md - Clio Project
 
-**Workflow:** Full AssemblyZero workflow. Read `C:\Users\mcwiz\Projects\AssemblyZero\WORKFLOW.md`.
-
----
+You are a team member on the Clio project, not a tool.
 
 ## Project Identifiers
 
 - **Repository:** `martymcenroe/Clio`
-- **Worktree Pattern:** `Clio-{IssueID}`
+- **Project Root (Windows):** `C:\Users\mcwiz\Projects\Clio`
+- **Project Root (Unix):** `/c/Users/mcwiz/Projects/Clio`
+- **Worktree Pattern:** `Clio-{IssueID}` (e.g., `Clio-156`)
 
----
+## Project-Specific Context
 
-## Project Overview
+**Stack:** Chrome extension, Manifest V3, JavaScript. Tests via jest + jsdom. Python tooling under `tools/`.
 
 Chrome extension for extracting full Gemini, Claude, and ChatGPT conversations to structured JSON with images. Named after the Greek Muse of History.
 
@@ -32,9 +32,7 @@ Chrome extension for extracting full Gemini, Claude, and ChatGPT conversations t
 - `extensions/src/selectors-chatgpt.js` — ChatGPT selectors
 - `extensions/src/popup.html` / `popup.js` — Extension popup UI
 
----
-
-## Development
+### Development
 
 ```bash
 npm test
@@ -46,3 +44,7 @@ npm run test:coverage
 - **Fail Open for Images:** Image errors logged, don't fail extraction
 - **Fail Closed for Text:** No messages found = extraction fails
 - **Local Processing Only:** No data sent to external servers
+
+## Workflow Overrides
+
+_None yet. If this project needs to override any universal CLAUDE.md rule (e.g., a custom merge tool, a special test convention), document the override here with explicit language ("override") per ADR 0219._


### PR DESCRIPTION
## Summary

Resolves lint marker 9 (hardcoded ``C:\Users\mcwiz\...`` path outside Project Identifiers block) and aligns Clio/CLAUDE.md with the lean ADR 0219 template.

## What changed

- **Removed** the line-3 ``Read WORKFLOW.md`` instruction (``/onboard`` reads ``.unleashed.json:assemblyZero=true`` and auto-loads AssemblyZero CLAUDE.md -- explicit "read this" is unnecessary per ADR 0219)
- **Preserved** all Clio-specific load-bearing content: Project Overview, Architecture table, Key Files list, Development commands, Design Principles
- **Added** scaffolder-parity scaffolding: full Project Identifiers (Windows + Unix + worktree-pattern example), "team member, not a tool" preamble, Workflow Overrides footer

## Test plan

- [x] ``poetry run python tools/lint_per_repo_claude_md.py`` (from AssemblyZero) reports ``Clio-156: PASS``, 50 lines, 0 findings
- [x] All Chrome-extension architecture docs preserved verbatim
- [x] Design Principles preserved (Fail Open Images / Fail Closed Text / Local Processing Only)

Closes #156

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)