### PR TITLE
docs: restructure CWS runbook 30002 (Closes #159, Closes #160)

### DIFF
--- a/docs/runbooks/30002-chrome-web-store-publish.md
+++ b/docs/runbooks/30002-chrome-web-store-publish.md
@@ -1,83 +1,92 @@
-# 30002 — Chrome Web Store Publishing
+# 30002 — Chrome Web Store Publishing (Clio)
 
-## Purpose
+> **Version:** 2
+> **Last updated:** 2026-05-28
+> **Applies to:** Clio Chrome extension, every submission to the Chrome Web Store
+> **Account-setup material:** moved to [`30004-cws-account-setup.md`](./30004-cws-account-setup.md)
 
-Step-by-step instructions for publishing Clio extension updates to the Chrome Web Store. Covers building, uploading, listing maintenance, and post-publish verification. This is the canonical procedure for both first submission and every subsequent update — follow it end to end, do not skip "obvious" steps.
+## How to verify you have the latest copy
 
-Adapted from Aletheia's runbook 10905; Clio differs in being Chrome-only (no Firefox AMO) and having a substantially smaller permission surface.
+This runbook lives at `docs/runbooks/30002-chrome-web-store-publish.md` in [martymcenroe/Clio](https://github.com/martymcenroe/Clio). The **Version** and **Last updated** lines above identify which revision you're holding.
 
-## Account
+To compare a printed copy against the canonical:
 
-| Store | Account | Dashboard |
-|-------|---------|-----------|
-| Chrome Web Store | `cto@thrivetech.ai` | https://chrome.google.com/webstore/devconsole |
+1. Note the version number on your copy
+2. From the repo, `git pull --ff-only` on `main`
+3. Open the freshly-pulled file and check the version line
+4. If the version differs, re-print before continuing
 
-This is the same developer account Aletheia publishes under. The one-time $5 USD developer-registration fee has already been paid against this account — there is no additional fee for publishing Clio under the same account.
+The §17 Change log at the bottom of this file lists every version with what changed.
 
-**Multi-account hazard.** This Google identity is one of many Google accounts the publisher may have signed in to in any given Chrome profile. Selecting the wrong account at the dashboard sign-in step is the most common source of "I can't find my extension" confusion at upload time. See the *First-time setup and account verification* section below.
+## 1. Where to start (reading paths)
 
-Firefox AMO is *not* in scope for the initial 1.4.0 launch. A future issue will track Firefox publication; the extension currently only ships for Chromium browsers.
+Pick the path that matches your situation; sections you don't need can be skipped on this submission.
 
-## First-time setup and account verification
+| Situation | Read sections |
+|-----------|--------------|
+| **Path A — First Clio submission** (CWS Items list does not show Clio yet) | §2 → §3 → §4 → §5 → §7 → §8 → §9 → §10 → §11 → §12 |
+| **Path B — Subsequent Clio update** (CWS Items list shows Clio) | §2 → §3 → §4 → §6 → §11 → §12 |
+| **Path C — New machine, new Chrome profile, or new publisher account** | Stop. Read [`30004-cws-account-setup.md`](./30004-cws-account-setup.md) first, then return here as Path A or Path B |
 
-Skip this section if you have already published to CWS from this account on this machine. The steps below are for a fresh machine, a new browser profile, or first-time publishers.
+§13 Version bump procedure, §14 Troubleshooting, §15 Release notes, §16 Related documents, §17 Change log are reference material — skim once, then return as needed.
 
-### Account verification before any upload
+## 2. Account check (every submission)
 
-1. Open a new Chrome window. Go to https://chrome.google.com/webstore/devconsole.
-2. If Chrome prompts for account selection, **carefully choose `cto@thrivetech.ai`** — not any other Google account that may be signed in. The chooser shows each account's display name and avatar; verify the email at the bottom of the chooser tile before clicking.
-3. If signed in to a different account, sign out completely first (https://accounts.google.com/Logout) — *do not* use "Add another account" alongside other Google sessions; the dashboard sometimes silently uses the default browser identity rather than the one you intended.
-4. Once in the dashboard, confirm in the **top-right avatar menu** that the active identity shows `cto@thrivetech.ai`. If it shows anything else, abort and re-do step 2.
+Whether this is the first submission or the hundredth, verify the correct identity before any upload:
 
-### One-time developer registration (already done for this account)
+1. Open `https://chrome.google.com/webstore/devconsole`
+2. The top-right **Publisher** chip must read `ThriveTech.ai`
+3. Click the avatar (top-right) to confirm the active account email is `cto@thrivetech.ai`
+4. If it's any other Google identity: sign out fully (`https://accounts.google.com/Logout`), close all Chrome windows, re-open, navigate to the dashboard again, choose `cto@thrivetech.ai` from the picker
 
-Documented here for future maintainers. If a new CWS publisher account ever needs to be created:
+Full account-setup detail (registration, multi-account hazard explanation, first-time verification) lives in [`30004-cws-account-setup.md`](./30004-cws-account-setup.md). This §2 is just the in-line check; if it fails, that runbook is the diagnostic path.
 
-1. Sign in to the dashboard at the URL above with the new Google identity
-2. Accept the Chrome Web Store Developer Agreement
-3. Pay the **one-time $5 USD registration fee** (Google Pay or credit card)
-4. Verify a contact email address (Google sends a verification email; the link must be clicked from the same browser session)
-5. The account is now eligible to publish
+## 3. Pre-flight checklist
 
-For `cto@thrivetech.ai` this is already done — the account already has Aletheia published under it and Clio inherits that registration.
+Split by responsibility. Agent items happen in the repo. Operator items happen on the publishing machine and dashboard. Each party checks their own before handing off.
 
-### Verifying Clio's presence in the dashboard
+### 3a. Agent does (in the repo, before producing the ZIP)
 
-After verifying the account (above), the dashboard's main view is the **Item list** — a left sidebar with each extension this account publishes. For the first Clio upload, Clio will not appear in this list until the New Item flow completes (see Upload section). For subsequent updates, Clio appears with its current version, last update date, and review status.
+- [ ] `extensions/manifest.json` has the new `version` value, monotonically increasing from the last published version
+- [ ] `host_permissions` is exactly `gemini.google.com`, `claude.ai`, `chatgpt.com` plus any image hosts already justified (currently `https://*.googleusercontent.com/*` for Gemini images)
+- [ ] `permissions` is exactly `activeTab`, `downloads`, `scripting`
+- [ ] No `console.log` / `console.debug` / `console.info` / `console.warn` / `console.error` left in shipped `extensions/src/*.js` (the v1.4.0 → v1.4.1 patch was driven by exactly this miss)
+- [ ] No hardcoded test URLs, dev flags, or scratch code
+- [ ] All tests pass: `npm test`
+- [ ] Lint clean: `npm run lint` (no warnings, not just no errors)
+- [ ] Version bump merged to `main` — build from `main`, never a feature branch
+- [ ] `CHANGELOG.md` has a dated entry for this version (not `[Unreleased]`)
+- [ ] Release notes file `docs/releases/chrome-vX.Y.Z.md` written before upload — see §15
 
-## Pre-flight checklist
+### 3b. Operator does (on the publishing machine)
 
-Before publishing, verify:
+- [ ] §2 Account check passes — Publisher chip reads `ThriveTech.ai` and avatar email is `cto@thrivetech.ai`
+- [ ] The version isn't already in the dashboard — for Path B updates, check the Package tab's version-history. For Path A first submissions, Clio doesn't exist in the Items list yet, so this is auto-pass.
+- [ ] Listing screenshots ready at the required resolution (1280×800 PNG) with no operator-personal info visible
+- [ ] `docs/listing-copy.md` reviewed (or intentionally skipped) for any text changes since last submission
+- [ ] This runbook's version line matches `main` (see "How to verify you have the latest copy" above)
 
-- [ ] `extensions/manifest.json` has the correct new `version` number
-- [ ] `host_permissions` contains exactly `gemini.google.com`, `claude.ai`, `chatgpt.com` — no more, no less
-- [ ] `permissions` contains exactly `activeTab`, `downloads`
-- [ ] No dev/debug code (no `console.log` lingering, no hardcoded URLs, no test flags) — see `chrome-web-store` issue #83 for the pre-launch sweep
-- [ ] All tests pass (`npm test`)
-- [ ] Lint passes (`npm run lint`) with no warnings
-- [ ] Version is NOT already published — check the dashboard before bumping
-- [ ] The version-bump change is merged to `main` (do not build from a feature branch)
-- [ ] `CHANGELOG.md` has a dated entry for this version, not `Unreleased`
+If any agent box is unchecked, the agent rebuilds before handing off the ZIP. If any operator box is unchecked, the operator pauses before clicking Upload.
 
-## Build the ZIP
+## 4. Build the ZIP
 
-**CRITICAL:** Always use `zip` from MSYS2 / Git Bash. **Never** use PowerShell `Compress-Archive` — it writes backslash path separators, which the Chrome Web Store reviewer flags as malformed.
+**CRITICAL:** Use `zip` from MSYS2 / Git Bash. Never PowerShell `Compress-Archive` — it writes backslash separators, which the CWS reviewer flags as malformed.
 
-**CRITICAL:** Verify the `extensions/` directory contains only extension files — no `docs/`, `tests/`, `tools/`, `node_modules/`, or other non-extension content. If a stray file slipped into the directory, fix that *before* building.
+**CRITICAL:** `extensions/` must contain only extension files. No `docs/`, `tests/`, `tools/`, `node_modules/`, or other content. Verify before zipping.
 
 ```bash
 cd /c/Users/mcwiz/Projects/Clio
 python tools/build_release.py  # produces dist/clio-chrome-vX.Y.Z.zip
 ```
 
-If `tools/build_release.py` does not yet exist for this version of the repo, fall back to a direct `zip` invocation:
+Fallback if `tools/build_release.py` is missing or broken:
 
 ```bash
 cd /c/Users/mcwiz/Projects/Clio/extensions
 zip -r ../dist/clio-chrome-vX.Y.Z.zip . -x '.*' -x '*/.*' -x 'node_modules/*'
 ```
 
-### Verify the ZIP
+### 4a. Verify the ZIP
 
 ```bash
 cd /c/Users/mcwiz/Projects/Clio
@@ -86,13 +95,13 @@ unzip -l dist/clio-chrome-vX.Y.Z.zip
 
 Confirm:
 
-- Forward slashes in all listed paths (no backslashes)
-- `manifest.json` present at the archive root
+- Forward slashes in all paths (no backslashes)
+- `manifest.json` at the archive root
 - `src/`, `icons/` present
-- 4 icons: 16, 32, 48, 128
-- No unexpected files (docs, session logs, dotfiles, dev-only scratch files)
+- Four icons: 16, 32, 48, 128
+- No unexpected files (docs, session logs, dotfiles, scratch files)
 
-A sanity check on the manifest version inside the ZIP:
+Sanity-check the manifest version inside the ZIP:
 
 ```bash
 unzip -p dist/clio-chrome-vX.Y.Z.zip manifest.json | grep '"version"'
@@ -100,50 +109,43 @@ unzip -p dist/clio-chrome-vX.Y.Z.zip manifest.json | grep '"version"'
 
 The reported version must match the ZIP filename.
 
-## Upload to the Chrome Web Store
+## 5. First submission upload (Path A — Clio not yet in the dashboard)
 
-### Pre-conditions
+Use this section only if Clio does **not** appear in the dashboard's Items list. (Confirmation cue: the Items list shows Aletheia but no Clio row.)
 
-- ZIP built and verified per the previous sections (`dist/clio-chrome-vX.Y.Z.zip` exists)
-- Signed in to dashboard as `cto@thrivetech.ai` — verified per *First-time setup and account verification* above
+1. From the dashboard, click **+ New item** (top-right of the Items list — blue button with plus icon)
+2. The "Upload your item" dialog opens. Click **Choose file** and select `dist/clio-chrome-vX.Y.Z.zip`
+3. Click **Upload**. Validation runs (10–60 s). Validation errors appear inline — fix them in source, rebuild, re-upload before proceeding
+4. On successful validation, CWS creates a draft listing for Clio and routes you to the **Store listing** tab. Continue with §7 Store listing.
 
-### First publish (Clio not yet in the dashboard)
+## 6. Subsequent update upload (Path B — Clio already in the dashboard)
 
-1. Go to https://chrome.google.com/webstore/devconsole
-2. Confirm top-right avatar shows `cto@thrivetech.ai` (multi-account hazard)
-3. Click the **+ New Item** button (top of the Item list, typically a prominent button labeled with a plus or "Add new item")
-4. The "Upload your item" dialog appears. Click **Choose file** and select `dist/clio-chrome-vX.Y.Z.zip`
-5. Click **Upload**. The dashboard validates the package — this takes 10–60 seconds. Validation errors appear inline; fix them in the source, rebuild, and re-upload before proceeding.
-6. On successful validation, the dashboard creates a draft listing for Clio and navigates to the **Store listing** tab. Continue with the *Store listing* section below.
+Use this section only if Clio appears as a row in the Items list.
 
-### Subsequent updates (Clio already in the dashboard)
+1. From the dashboard, click the **Clio** row to open its listing
+2. Left sidebar → **Package**
+3. Click **Upload new package** (top of the Package tab)
+4. Choose `dist/clio-chrome-vX.Y.Z.zip` and upload
+5. Validation runs. On success, the new version becomes the draft. The previously-published version remains live until this draft is submitted and approved.
 
-1. Go to https://chrome.google.com/webstore/devconsole
-2. Confirm top-right avatar shows `cto@thrivetech.ai`
-3. From the Item list, click the **Clio** row to open its dashboard
-4. In the left sidebar, click **Package**
-5. Click **Upload new package** (button near the top of the Package tab)
-6. Choose `dist/clio-chrome-vX.Y.Z.zip` and upload
-7. Validation runs; on success, the new version becomes the draft. The previously-published version remains live until this draft is submitted and approved.
+## 7. Store listing
 
-## Store listing
+Update fields if changed. Canonical text lives in `docs/listing-copy.md` — paste from there rather than typing.
 
-Update if changed (see `docs/listing-copy.md` for the canonical text):
-
-| Field | Value |
-|-------|-------|
+| Field | Value / Source |
+|-------|---------------|
 | Name | Clio |
-| Short Description | (132 char max) — see `docs/listing-copy.md` |
-| Long Description | — see `docs/listing-copy.md` |
+| Short Description | 132 char max — see `docs/listing-copy.md` |
+| Long Description | See `docs/listing-copy.md` |
 | Category | Productivity |
 | Language | English |
 
-## Privacy tab
+## 8. Privacy tab
 
 | Field | Value |
 |-------|-------|
 | Single Purpose | Extract LLM conversations from supported assistant sites (Gemini, Claude, ChatGPT) to local JSON files for user-side archival |
-| Privacy Policy URL | `https://martymcenroe.github.io/Clio/privacy.html` *(verify the GH Pages site is live before submission; see #88)* |
+| Privacy Policy URL | `https://cliocast.com/privacy` |
 | Handles user data? | Yes — page content (conversation text and images visible in the active tab) |
 | Sold to 3rd parties? | No |
 | Used for unrelated purposes? | No |
@@ -157,23 +159,25 @@ Update if changed (see `docs/listing-copy.md` for the canonical text):
 | Health info | No | — |
 | Financial info | No | — |
 | Authentication info | No | — |
-| Personal communications | **Yes** | The conversation text the user is viewing. Processed locally, never transmitted off-device. |
+| Personal communications | **Yes** | Conversation text the user is viewing. Processed locally, never transmitted off-device. |
 | Location | No | — |
 | Web history | No | — |
 | User activity | No | — |
 | Website content | **Yes** | DOM of the active tab on the three declared LLM sites only, on user-initiated extraction. Processed locally. |
 
-## Permission justifications
+## 9. Permission justifications
 
 | Permission | Justification |
 |------------|---------------|
 | `activeTab` | Required to read the conversation DOM in the user's current tab when they press the extension's toolbar button. Activated by user gesture only; not a standing capability. |
-| `downloads` | Required to write the extracted ZIP to the user's local disk via Chrome's "Save As" dialog. This is the only way the extension writes any data anywhere. |
-| `host_permissions: gemini.google.com, claude.ai, chatgpt.com` | The three LLM products Clio supports. Content scripts walk the DOM on these origins only to enumerate conversation turns. No other origin is contacted. |
+| `downloads` | Required to write the extracted ZIP to the user's local disk via Chrome's "Save As" dialog. The only way the extension writes data anywhere. |
+| `scripting` | Required for the auto-recovery path when the content script's listener has been torn down (typically after a tab reload). Used only after a "Receiving end does not exist" error, only on the active tab, only to inject Clio's own bundled scripts. |
+| `host_permissions: gemini.google.com, claude.ai, chatgpt.com` | The three LLM products Clio supports. Content scripts walk the DOM on these origins only to enumerate conversation turns. |
+| `host_permissions: https://*.googleusercontent.com/*` | Required to fetch images embedded in Gemini conversations for inclusion in the extracted ZIP. Read-only image fetches, only when extracting a Gemini conversation. |
 
-If a reviewer asks why these justifications are unusually short: because the extension genuinely does very little. The minimum-surface-area posture is documented in `SECURITY.md` and the wiki's Defense in Depth page.
+If a reviewer asks why the justifications are unusually short: because the extension genuinely does very little. The minimum-surface-area posture is documented in `SECURITY.md` and the wiki's Defense in Depth page.
 
-## Pricing & distribution
+## 10. Pricing & distribution
 
 | Field | Value |
 |-------|-------|
@@ -182,51 +186,52 @@ If a reviewer asks why these justifications are unusually short: because the ext
 | Regions | All regions |
 | Pricing | Free |
 
-## Submit for review
+## 11. Submit for review
 
 1. Click **Submit for review**
 2. Chrome review typically takes 1–3 business days
 3. Note the submission date and time in GitHub issue #95
 
-## Post-publish verification
+## 12. Post-publish verification
 
 After the extension is approved and live:
 
-1. Install from the Chrome Web Store listing on a clean Chrome profile
+1. Install from the CWS listing on a clean Chrome profile
 2. **Gemini smoke test:** open a Gemini conversation → click the Clio toolbar icon → click Extract → verify a valid ZIP downloads and the JSON parses
 3. **Claude smoke test:** repeat on a Claude conversation
 4. **ChatGPT smoke test:** repeat on a ChatGPT conversation
-5. Check the version number in `chrome://extensions` matches what was uploaded
+5. Verify `chrome://extensions` shows the version that was uploaded
 6. Update the README install link to the live CWS URL (separate PR)
 7. Update `docs/index.html` install link (separate PR)
-8. Tag the released commit on the repo: `git tag vX.Y.Z-published && git push origin vX.Y.Z-published`
-9. Note the approval date and live URL in GitHub issue #95, then close it
+8. Tag the released commit: `git tag vX.Y.Z-published && git push origin vX.Y.Z-published`
+9. Note the approval date and live URL in #95, then close it
 
-If any smoke test fails: do **not** delist immediately. File a `launch-blocker` issue, reproduce in dev mode, fix and ship a patch version. A version on the store that mostly works is recoverable; a removed listing has to go through review again from scratch.
+If any smoke test fails: do **not** delist immediately. File a `launch-blocker` issue, reproduce in dev mode, fix and ship a patch version. A version on the store that mostly works is recoverable; a removed listing has to go through review from scratch.
 
-## Version bump procedure
+## 13. Version bump procedure
 
 When preparing a new release:
 
 1. Open a GitHub issue describing the release contents — link to the closed work that's bundled in
 2. Update `extensions/manifest.json` → `"version": "X.Y.Z"`
-3. Update `CHANGELOG.md` `[Unreleased]` → `[X.Y.Z] - YYYY-MM-DD` with the actual release contents
+3. Update `CHANGELOG.md` `[Unreleased]` → `[X.Y.Z] - YYYY-MM-DD` with the actual contents
 4. Commit: `chore: bump extension version to X.Y.Z (Closes #N)`
 5. Merge to `main`
-6. Then follow the build and upload steps above
+6. Then follow §4 Build and §5 or §6 Upload above
 
-## Troubleshooting
+## 14. Troubleshooting
 
 | Problem | Diagnosis | Action |
 |---------|-----------|--------|
-| CWS rejects ZIP with "invalid path" or backslash error | ZIP built with PowerShell | Rebuild with `zip` (MSYS2/Git Bash) |
-| "Version already exists" | Forgot to bump | Update manifest, re-build |
-| Chrome review rejection (permission justification) | Reviewer wants more detail | Read the rejection carefully — usually a specific permission needs a more concrete user-benefit framing; do not dilute the justification just to satisfy them |
-| Extension ZIP contains unexpected files | Stray dev artifacts under `extensions/` | Locate and remove; verify `extensions/` is *only* extension files before re-zipping |
-| Privacy Policy URL "not reachable" | GH Pages not live yet | Wait for #88 to land; verify URL resolves before re-submitting |
-| Manifest validation fails on icon dimensions | Missing 32px or asymmetric image dimensions | Check `icons/` for all four sizes; regenerate if needed (see `docs/design/icon_prompts.md`) |
+| CWS rejects ZIP with "invalid path" or backslash error | ZIP built with PowerShell | Rebuild with `zip` (MSYS2 / Git Bash) |
+| "Version already exists" | Forgot to bump | Update manifest, rebuild |
+| Reviewer rejection (permission justification) | Reviewer wants more detail | Read rejection carefully — usually a specific permission needs a more concrete user-benefit framing; do not dilute justification just to satisfy them |
+| ZIP contains unexpected files | Stray dev artifacts under `extensions/` | Locate and remove; verify `extensions/` is only extension files before re-zipping |
+| Privacy Policy URL "not reachable" | Domain or page down | Verify `https://cliocast.com/privacy` resolves with HTTP 200 in a fresh browser before re-submitting |
+| Manifest validation fails on icon dimensions | Missing 32px or asymmetric dimensions | Check `icons/` for all four sizes; regenerate if needed (see `docs/design/icon_prompts.md`) |
+| Avatar shows wrong account at dashboard | Multi-account hazard | Sign out fully, close Chrome, re-open, choose `cto@thrivetech.ai` from picker; full diagnostic in [`30004-cws-account-setup.md`](./30004-cws-account-setup.md) |
 
-## Release notes
+## 15. Release notes
 
 Per-version release notes live in `docs/releases/` with the naming convention:
 
@@ -238,14 +243,23 @@ Each file should contain:
 2. **Reviewer notes** — what the CWS reviewer sees (permission justifications, testing instructions if non-obvious)
 3. The previous version number and the submission date
 
-Create the release notes file *before* uploading — it serves as the source of truth for the dashboard's text fields, so you're not typing them live into a web form.
+Create the release notes file **before** uploading — it serves as the source of truth for the dashboard's text fields, so you're not typing them live into a web form.
 
-## Related documents
+## 16. Related documents
 
-- `docs/releases/` — release notes archive
+- [`30001-development-runbook.md`](./30001-development-runbook.md) — dev-mode setup, test workflow, versioning policy
+- [`30003-cloudflare-pages-setup.md`](./30003-cloudflare-pages-setup.md) — CFP setup for cliocast.com
+- [`30004-cws-account-setup.md`](./30004-cws-account-setup.md) — CWS publisher account creation, registration, multi-account hazard, identity verification
 - `docs/listing-copy.md` — canonical store-listing text (name, descriptions, category)
-- `docs/runbooks/30001-development-runbook.md` — dev-mode setup, test workflow
+- `docs/releases/` — per-version release notes archive
 - `PRIVACY.md` — public privacy policy
 - `SECURITY.md` — threat model and vulnerability reporting
-- `extensions/manifest.json` — the ground-truth permission declaration
+- `extensions/manifest.json` — ground-truth permission declaration
 - Aletheia runbook 10905 — original source this was adapted from
+
+## 17. Change log
+
+| Version | Date | Change |
+|---------|------|--------|
+| 2 | 2026-05-28 | Added version/date header and "how to verify you have the latest copy" section. Numbered all top-level sections §1–§17. Added §1 Quick Start with Path A / Path B / Path C reading-path matrix. Split §3 Pre-flight into §3a Agent and §3b Operator. Moved account-setup material (multi-account hazard, one-time developer registration, first-machine verification) to [`30004-cws-account-setup.md`](./30004-cws-account-setup.md); 30002 now keeps only the in-line §2 Account check. Added `scripting` and `*.googleusercontent.com` permission justifications to §9. Updated privacy-policy URL to `cliocast.com/privacy`. Closes #159, #160. |
+| 1 | 2026-05-22 | Initial Clio-adapted version (forked from Aletheia runbook 10905). |

--- a/docs/runbooks/30004-cws-account-setup.md
+++ b/docs/runbooks/30004-cws-account-setup.md
@@ -1,0 +1,80 @@
+# 30004 — Chrome Web Store Account Setup (New Extension Starter)
+
+> **Version:** 1
+> **Last updated:** 2026-05-28
+> **Applies to:** Any new Chrome extension before its first CWS submission, or any first-time login from a new machine / new Chrome profile
+
+## Purpose
+
+Pre-conditions for getting an extension onto the Chrome Web Store under the `cto@thrivetech.ai` publisher: account verification, multi-account hazard, one-time developer registration, dashboard orientation. Once these are satisfied, hand off to the extension-specific publishing runbook (e.g. Clio's [`30002-chrome-web-store-publish.md`](./30002-chrome-web-store-publish.md)).
+
+If the account already publishes to CWS and you're verifying you're signed in correctly on a familiar machine, that's a single check — done inline in the extension-specific runbook (Clio's §2 Account check). This document covers the cases where that single check is not enough:
+
+- A new Chrome profile or new machine has not yet signed in to the dashboard, OR
+- A new publisher account is being created from scratch, OR
+- The multi-account hazard has bitten the operator and they need the full diagnostic.
+
+## How to verify you have the latest copy
+
+This runbook lives at `docs/runbooks/30004-cws-account-setup.md` in [martymcenroe/Clio](https://github.com/martymcenroe/Clio). The **Version** and **Last updated** lines above identify which revision you're holding. To compare against the canonical: `git pull --ff-only` on `main` and check the version line in the freshly-pulled file.
+
+## 1. Account
+
+| Store | Account | Dashboard |
+|-------|---------|-----------|
+| Chrome Web Store | `cto@thrivetech.ai` | https://chrome.google.com/webstore/devconsole |
+
+This is the developer account that Aletheia, Clio, and any future ThriveTech extensions publish under. The one-time $5 USD developer-registration fee has already been paid against this account — no additional fee for new extensions under it.
+
+## 2. Multi-account hazard
+
+This Google identity is one of many Google accounts the publisher may be signed in to in any given Chrome profile. Selecting the wrong account at the dashboard sign-in step is the most common source of "I can't find my extension" confusion at upload time.
+
+### 2a. Verifying the active identity
+
+1. Open a new Chrome window. Go to https://chrome.google.com/webstore/devconsole
+2. If Chrome prompts for account selection, **carefully choose `cto@thrivetech.ai`** — not any other Google account that may be signed in. The chooser shows each account's display name and avatar; verify the email at the bottom of the chooser tile before clicking.
+3. If signed in to a different account, sign out completely first (https://accounts.google.com/Logout) — do **not** use "Add another account" alongside other Google sessions; the dashboard sometimes silently uses the default browser identity rather than the intended one.
+4. Once in the dashboard, confirm in the **top-right** header that the **Publisher** chip reads `ThriveTech.ai`, and that the avatar's account email (click avatar to see) is `cto@thrivetech.ai`. If anything else, abort and re-do step 2.
+
+## 3. One-time developer registration (already done for `cto@thrivetech.ai`)
+
+Documented here for future maintainers. If a new CWS publisher account ever needs to be created:
+
+1. Sign in to the dashboard at the URL above with the new Google identity
+2. Accept the Chrome Web Store Developer Agreement
+3. Pay the **one-time $5 USD registration fee** (Google Pay or credit card)
+4. Verify a contact email address — Google sends a verification email; the link must be clicked from the same browser session
+5. The account is now eligible to publish
+
+For `cto@thrivetech.ai` this is already done. The account currently has Aletheia published; Clio and any future extensions inherit that registration.
+
+## 4. Item list orientation
+
+After verifying the account, the dashboard's main view is the **Items** list — a left sidebar with each extension this account publishes. For a new extension's first upload, the new extension will not appear in this list until the New Item flow completes (see the extension-specific runbook). For subsequent updates, the extension appears with its current version, last update date, and review status.
+
+Items list state as of this runbook's last-updated date:
+
+| Item | Version | Type | Created | Last updated | Status |
+|------|---------|------|---------|--------------|--------|
+| Aletheia | 1.1.2 | Extension | Jan 8, 2026 | May 25, 2026 | Published — public |
+
+Once Clio's first **+ New item** flow completes, Clio will appear as a second row.
+
+## 5. Next steps
+
+Once the account is verified per this runbook, return to the extension-specific publishing runbook:
+
+- **Clio** → [`30002-chrome-web-store-publish.md`](./30002-chrome-web-store-publish.md), pick the reading path (Path A first submission, Path B subsequent update)
+- **Future ThriveTech extensions** → that extension's own 3000X runbook (create following Clio's 30002 as a template)
+
+## 6. Related documents
+
+- [`30002-chrome-web-store-publish.md`](./30002-chrome-web-store-publish.md) — Clio publishing runbook (recurring submission flow)
+- Aletheia runbook 10905 — original source the Clio runbook was adapted from
+
+## 7. Change log
+
+| Version | Date | Change |
+|---------|------|--------|
+| 1 | 2026-05-28 | Initial — extracted account-setup boilerplate from `30002-chrome-web-store-publish.md` so 30002 stays focused on the recurring submission flow. Closes #160. |


### PR DESCRIPTION
## Summary

- 30002 gets a version+date header, "how to verify you have the latest copy" guidance, §1 Quick Start reading-path matrix, numbered sections §1–§17, split §3 Pre-flight into §3a Agent / §3b Operator, expanded §9 permission justifications (`scripting`, `*.googleusercontent.com`), privacy URL corrected to `cliocast.com/privacy`, §17 Change log
- New 30004-cws-account-setup.md holds the account-identity / multi-account-hazard / one-time-registration / item-list-orientation material that used to clutter 30002
- 30002 §2 keeps the inline "is the right account signed in?" check; full diagnostic lives in 30004

Driven by operator feedback during prep for the first Clio CWS submittal (issue #95): printed copy had no version line so "is this current?" was unanswerable; doc demanded a top-to-bottom read every time; pre-flight items didn't make clear which party owned each check; new-account boilerplate was noise for a recurring submission flow.

## Test plan

- [ ] Both files render cleanly on GitHub (markdown tables, links, anchor jumps work)
- [ ] §1 Quick Start matrix correctly maps each reading path to the right sections
- [ ] Cross-links between 30002 and 30004 resolve (relative paths `./30002-...md` and `./30004-...md`)
- [ ] Existing references to runbook 30002 elsewhere in the repo still resolve — `grep -rn "30002-chrome-web-store"` reports the same files as before
- [ ] Operator opens the post-merge `main` version and confirms the structure matches what they asked for

Closes #159
Closes #160