### PR TITLE
docs(runbook): 30002 v8 — add Graphic assets / Additional fields / Item support in dashboard order (Closes #182)

### DIFF
--- a/docs/runbooks/30002-chrome-web-store-publish.md
+++ b/docs/runbooks/30002-chrome-web-store-publish.md
@@ -1,7 +1,7 @@
 # 30002 — Chrome Web Store Publishing (Clio)
 
-> **Version:** 7
-> **Last updated:** 2026-05-28 3:40:27 PM Central
+> **Version:** 8
+> **Last updated:** 2026-05-28 3:45:01 PM Central
 > **Applies to:** Clio Chrome extension, every submission to the Chrome Web Store
 > **Tracking issue:** [martymcenroe/Clio#95](https://github.com/martymcenroe/Clio/issues/95)
 > **Account-setup material:** moved to [`30004-cws-account-setup.md`](./30004-cws-account-setup.md)
@@ -21,7 +21,7 @@ To compare a printed copy against the canonical:
 2. Say `Run pre-flight` or `Audit 30002` (see §0) — the agent reports the current `main` HEAD's runbook version line as part of its output
 3. If your copy's version differs, re-print before continuing
 
-The §17 Change log at the bottom of this file lists every version with what changed.
+The §20 Change log at the bottom of this file lists every version with what changed.
 
 ## 0. Invoke the agent (canonical phrases)
 
@@ -34,7 +34,7 @@ The operator types one of these phrases into the agent chat to trigger the match
 | Run §3a only (no build) and report findings | `Run §3a` |
 | Run §4 build + verify (pre-flight already passed) | `Run §4` |
 | Comment submission date on #95 (uses current Central time, or pass `at YYYY-MM-DD HH:MM`) | `Submitted` |
-| After CWS approves: run §12a — README + `docs/index.html` install-link update PR, tag the commit, comment + close #95 | `Run post-publish <live CWS URL>` |
+| After CWS approves: run §15a — README + `docs/index.html` install-link update PR, tag the commit, comment + close #95 | `Run post-publish <live CWS URL>` |
 
 The agent's reply to any of these includes: (a) a one-line confirmation of what it just did, (b) any findings or follow-ups, (c) the current `main` HEAD's runbook version line so the operator can sanity-check their printed copy on every turn.
 
@@ -44,11 +44,11 @@ Pick the path that matches your situation; sections you don't need can be skippe
 
 | Situation | Read sections |
 |-----------|--------------|
-| **Path A — First Clio submission** (CWS Items list does not show Clio yet) | §2 → §3 → §4 → §5 → §7 → §8 → §9 → §10 → §11 → §12 |
-| **Path B — Subsequent Clio update** (CWS Items list shows Clio) | §2 → §3 → §4 → §6 → §11 → §12 |
+| **Path A — First Clio submission** (CWS Items list does not show Clio yet) | §2 → §3 → §4 → §5 → §7 → §8 → §9 → §10 → §11 → §12 → §13 → §14 → §15 |
+| **Path B — Subsequent Clio update** (CWS Items list shows Clio) | §2 → §3 → §4 → §6 → (review §7–§13 if listing copy changed) → §14 → §15 |
 | **Path C — New machine, new Chrome profile, or new publisher account** | Stop. Read [`30004-cws-account-setup.md`](./30004-cws-account-setup.md) first, then return here as Path A or Path B |
 
-§13 Version bump procedure, §14 Troubleshooting, §15 Release notes, §16 Related documents, §17 Change log are reference material — skim once, then return as needed.
+§16 Version bump procedure, §17 Troubleshooting, §18 Release notes, §19 Related documents, §20 Change log are reference material — skim once, then return as needed.
 
 ## 2. Account check (every submission)
 
@@ -68,7 +68,7 @@ Split by responsibility. **Agent items** happen in the repo. **Operator items** 
 ### 3a. Agent does (in the repo, before producing the ZIP)
 
 1. `extensions/manifest.json` has the new `version` value, monotonically increasing from the last published version. For Path A first submission, no prior published version exists; auto-pass.
-2. `host_permissions` matches `extensions/manifest.json`'s `host_permissions` array. Each entry has a paste-block justification in §9. Adding a new host to the manifest requires also adding a §9 paste-block; if §9 has fewer entries than the manifest, that's the finding.
+2. `host_permissions` matches `extensions/manifest.json`'s `host_permissions` array. Each entry has a paste-block justification in §12. Adding a new host to the manifest requires also adding a §12 paste-block; if §12 has fewer entries than the manifest, that's the finding.
 3. `permissions` is exactly `activeTab`, `downloads`, `scripting`
 4. No live debug-tier console calls in `extensions/src/*.js`. **Banned:** live `console.log` / `console.debug` / `console.info` / `console.warn`. **Allowed:** `console.error` inside a `try/catch` that also surfaces the error to the user via the popup UI (e.g. `popup.js`'s extraction-error handler); commented-out calls; explanatory comments mentioning these by name.
 5. No hardcoded test URLs, dev flags, or scratch code
@@ -76,8 +76,8 @@ Split by responsibility. **Agent items** happen in the repo. **Operator items** 
 7. Lint clean: `npm run lint`. **Aspirational** — if `package.json` has no `lint` script, file (or reference) a tracking issue for eslint setup and continue. Do not block ship. (Current tracker: #165.)
 8. Version bump merged to `main` — build from `main`, never a feature branch
 9. `CHANGELOG.md` has a dated entry for this version (not `[Unreleased]`)
-10. Release notes file `docs/releases/chrome-vX.Y.Z.md` written before the §4 build — see §15
-11. Listing screenshots exist at `docs/assets/store/screenshot-*.png`, format PNG, dimensions 1280×800. Mechanical check; agent reports file list, sizes, and dimensions to the operator.
+10. Release notes file `docs/releases/chrome-vX.Y.Z.md` written before the §4 build — see §18
+11. Listing screenshots exist at `docs/assets/store/screenshot-*.png`, format **24-bit PNG (no alpha)**, dimensions **1280×800** (or 640×400; 1280×800 is the default). Mechanical check; agent reports file list, sizes, dimensions, and color mode (must be `RGB`, never `RGBA`) to the operator.
 12. Agent reads each `docs/assets/store/screenshot-*.png` and pre-describes what's visible (browser chrome, popup state, conversation content). Operator confirms in §3b.3 — agent's pre-description reduces operator's review from "from scratch" to "approve flag-list."
 13. Agent reports the current `main` HEAD commit SHA and the runbook's `> **Version:**` line so the operator can sanity-check their printed copy against ground truth.
 
@@ -86,7 +86,7 @@ Split by responsibility. **Agent items** happen in the repo. **Operator items** 
 1. §2 Account check passes — Publisher chip reads `ThriveTech.ai` and avatar email is `cto@thrivetech.ai`
 2. The version isn't already in the dashboard. For Path B updates, check the Package tab's version history. For Path A first submissions, Clio doesn't exist in the Items list yet; auto-pass.
 3. Operator approves agent's §3a.12 screenshot pre-description, or flags personal info / embarrassing content the agent missed
-4. §7 / §8 / §9 paste-blocks in this runbook reviewed (or intentionally skipped) for changes since last submission — these are the canonical source; no second document to open
+4. §7 through §12 paste-blocks and form values reviewed (or intentionally skipped) for changes since last submission — these are the canonical source; no second document to open
 5. Operator's printed copy version line matches the version the agent reported in §3a.13
 
 If any §3a item is unchecked, the agent fixes what it can (write missing release notes, file lint tracker, etc.) and surfaces the rest to the operator before producing the ZIP. If any §3b item is unchecked, the operator pauses before clicking Upload.
@@ -149,7 +149,7 @@ Use this section only if Clio does **not** appear in the dashboard's Items list.
 1. From the dashboard, click **+ New item** (top-right of the Items list — blue button with plus icon)
 2. The "Upload your item" dialog opens. Click **Choose file** and select `dist/clio-chrome-vX.Y.Z.zip`
 3. Click **Upload**. Validation runs (10–60 s). Validation errors appear inline — fix them in source, rebuild, re-upload before proceeding
-4. On successful validation, CWS creates a draft listing for Clio and routes you to the **Store listing** tab. Continue with §7 Store listing.
+4. On successful validation, CWS creates a draft listing for Clio and routes you to the **Store listing** tab. Continue with §7 → §8 → §9 → §10, then §11 Privacy, §12 Permissions, §13 Pricing.
 
 ## 6. Subsequent update upload (Path B — Clio already in the dashboard)
 
@@ -161,9 +161,9 @@ Use this section only if Clio appears as a row in the Items list.
 4. Choose `dist/clio-chrome-vX.Y.Z.zip` and upload
 5. Validation runs. On success, the new version becomes the draft. The previously-published version remains live until this draft is submitted and approved.
 
-## 7. Store listing
+## 7. Store listing — product details
 
-Update fields if changed. All text below is paste-ready — copy into the matching CWS form field.
+Update fields if changed. All text below is paste-ready — copy into the matching CWS form field. These are the top-of-the-form fields on the Store listing tab; §8, §9, and §10 are the rest of the same tab.
 
 ### 7a. Name
 
@@ -264,7 +264,85 @@ English (United States)
 cto@thrivetech.ai
 ```
 
-## 8. Privacy tab
+## 8. Store listing — graphic assets
+
+The **Graphic assets** section of the Store listing tab. Upload in dashboard order; the agent confirmed file existence + dimensions + format in §3a.11.
+
+### 8a. Store icon (required)
+
+**CWS requirement:** 128×128 PNG, follow Google's image guidelines.
+**File to upload:** `extensions/icons/icon128.png`
+
+Drag the file into the "Drop icon here" target. Same icon ships with the extension manifest (`manifest.json` → `icons.128`); `build_release.py` Step 1 verifies it exists and is non-empty as part of every build.
+
+### 8b. Global promo video (optional)
+
+YouTube URL input. **Skip** for v1.4.1 — Clio has no promo video. File a follow-up issue if shipping requires.
+
+### 8c. Screenshots (required, at least one)
+
+**CWS requirement:** 1280×800 or 640×400, JPEG or 24-bit PNG (no alpha). Up to 5.
+**Files to upload (in order):**
+- `docs/assets/store/screenshot-1.png` — Extraction-complete state on a Claude conversation
+- `docs/assets/store/screenshot-2.png` — Ready-to-extract state on a Claude conversation followup
+
+Drag each into the "Drop image here" target one at a time. Both files verified 1280×800 24-bit PNG (no alpha) by the agent in §3a.11. Content pre-described in §3a.12 and approved by operator in §3b.3.
+
+### 8d. Small promo tile (optional)
+
+**CWS requirement:** 440×280 canvas, JPEG or 24-bit PNG (no alpha).
+**File to upload:** *not yet produced — skip for v1.4.1*
+
+Required for featured-listing eligibility only. Future asset; file a follow-up issue if shipping the v1.5 release requires a featured-listing push.
+
+### 8e. Marquee promo tile (optional)
+
+**CWS requirement:** 1400×560 canvas, JPEG or 24-bit PNG (no alpha).
+**File to upload:** *not yet produced — skip for v1.4.1*
+
+Same featured-listing posture as §8d. Future asset.
+
+## 9. Store listing — additional fields
+
+The **Additional fields** section. Four inputs.
+
+### 9a. Official URL (dropdown)
+
+```
+None
+```
+
+To populate `cliocast.com` here, the publisher must first verify cliocast.com ownership in Google Search Console using the `cto@thrivetech.ai` Google account. Until that's done, `None` is the correct selection — `None` does not break the listing.
+
+### 9b. Homepage URL
+
+```
+https://cliocast.com
+```
+
+Project landing page (Cloudflare Pages, see [`30003-cloudflare-pages-setup.md`](./30003-cloudflare-pages-setup.md)). 2,048-char limit; well under.
+
+### 9c. Support URL
+
+```
+https://github.com/martymcenroe/Clio/issues
+```
+
+GitHub issue tracker — where users report bugs and request features. Matches the `Bug reports / feature requests` link strategy in `README.md`.
+
+### 9d. Mature content (toggle)
+
+Leave **off**. Clio is a developer/research utility; no sexual, violent, or substance-related content.
+
+## 10. Store listing — item support
+
+The **Item support** section is a single visibility toggle (`Change visibility here` link in the form). Per the dashboard's right-side help text, this controls whether the published listing surfaces an "item support" call-to-action linking to the §9c Support URL.
+
+**Recommended:** **On** (visible). Clio has an active GitHub issue tracker at the §9c URL; making it discoverable from the listing reduces the friction for a user to file a real issue instead of leaving a confused review.
+
+If the dashboard's current help text contradicts this recommendation (CWS UI text changes occasionally), defer to the dashboard for this submission, then file a runbook-update issue with what the dashboard actually said so the next operator doesn't have to re-discover.
+
+## 11. Privacy tab
 
 | Field | Value |
 |-------|-------|
@@ -274,7 +352,7 @@ cto@thrivetech.ai
 | Used for unrelated purposes? | No |
 | Used for creditworthiness or lending? | No |
 
-### 8a. Single-purpose description
+### 11a. Single-purpose description
 
 *CWS asks: "Describe the single purpose of your extension." Paste:*
 
@@ -282,7 +360,7 @@ cto@thrivetech.ai
 Export the user's own conversations with Claude, Gemini, and ChatGPT to a structured JSON file (plus any embedded images) on a single click, with no server-side component.
 ```
 
-### 8b. Data usage disclosures (Chrome's mandatory checklist)
+### 11b. Data usage disclosures (Chrome's mandatory checklist)
 
 | Data type | Collected? | Notes |
 |-----------|-----------|-------|
@@ -296,35 +374,35 @@ Export the user's own conversations with Claude, Gemini, and ChatGPT to a struct
 | User activity | No | — |
 | Website content | **Yes** | DOM of the active tab on the three declared LLM sites only, on user-initiated extraction. Processed locally. |
 
-## 9. Permission justifications
+## 12. Permission justifications
 
 CWS requires a written justification for each declared permission and host permission. Each block below is paste-ready into the matching field.
 
-### 9a. `activeTab`
+### 12a. `activeTab`
 
 ```
 Used to read the DOM of the currently active conversation tab when the user clicks the Clio icon. The extension does not access any other tab. activeTab is granted at click time and revoked when the user leaves the tab — Chrome enforces this scoping by design. This permission is the minimum required for the extension's stated function (one-click conversation export).
 ```
 
-### 9b. `downloads`
+### 12b. `downloads`
 
 ```
 Used to save the extracted conversation as a ZIP file to the user's computer. The ZIP is created entirely in the browser (via JSZip, bundled in the extension) and saved through Chrome's standard download flow to whatever folder the user has configured. No external upload, no server involvement.
 ```
 
-### 9c. `scripting`
+### 12c. `scripting`
 
 ```
 Used solely as a recovery path. When the user clicks Clio on a tab that was opened before Clio was installed or last reloaded, Chrome's content script hasn't been injected into that tab — clicking the extract button would otherwise fail with the raw error "Could not establish connection." The scripting permission lets Clio re-inject its own content script (the same files declared in the manifest's content_scripts entries) into the active tab so the extraction can proceed. It is invoked only on this specific failure path, only into the currently active tab, and only with Clio's own bundled scripts. It is not used to inject code into any other tab or at any other time.
 ```
 
-### 9d. Host permissions: `https://claude.ai/*`, `https://gemini.google.com/*`, `https://chatgpt.com/*`
+### 12d. Host permissions: `https://claude.ai/*`, `https://gemini.google.com/*`, `https://chatgpt.com/*`
 
 ```
 The content script must be allowed to run on these three AI chat sites in order to read the conversation DOM and extract message content. The script does not run on any other site. These three hosts are the entirety of the extension's web-surface — Clio has no business logic, fetches no analytics, and makes no requests outside the user's already-loaded conversation.
 ```
 
-### 9e. Host permissions: `https://*.googleusercontent.com/*`
+### 12e. Host permissions: `https://*.googleusercontent.com/*`
 
 ```
 Used to fetch user-uploaded image attachments from Gemini conversations. Gemini stores uploaded files at session-authenticated URLs on googleusercontent.com (e.g., lh3.googleusercontent.com). Without this host permission, the browser blocks the extension from fetching these images, leaving them missing from the ZIP. The extension only fetches images that are already embedded in the conversation the user is viewing — it does not read or modify any other content on these hosts. The wildcard covers the various lh3/lh4/lh5 subdomains Gemini may use depending on hash routing.
@@ -332,7 +410,7 @@ Used to fetch user-uploaded image attachments from Gemini conversations. Gemini 
 
 If a reviewer asks why the justifications are unusually short on any one permission: because the extension genuinely does very little. The minimum-surface-area posture is documented in `SECURITY.md` and the wiki's Defense in Depth page.
 
-## 10. Pricing & distribution
+## 13. Pricing & distribution
 
 | Field | Value |
 |-------|-------|
@@ -341,24 +419,24 @@ If a reviewer asks why the justifications are unusually short on any one permiss
 | Regions | All regions |
 | Pricing | Free |
 
-## 11. Submit for review
+## 14. Submit for review
 
 1. Operator clicks **Submit for review**
 2. Chrome review typically takes 1–3 business days
 3. Operator says `Submitted` to the agent. Agent runs `gh issue comment 95` with the current Central-time submission timestamp, or with the time the operator specified after `at`.
 
-## 12. Post-publish
+## 15. Post-publish
 
 After Chrome approves the listing and emails the operator that the version is live, the operator says `Run post-publish <live CWS URL>` to the agent. The two split:
 
-### 12a. Agent does (`Run post-publish <URL>`)
+### 15a. Agent does (`Run post-publish <URL>`)
 
 1. Update the README install link from "Coming soon" / dev-mode instructions to a direct CWS install link at the supplied URL — branch, commit, PR, merge
 2. Update `docs/index.html` install link (`<p class="install-note">Coming soon to the Chrome Web Store.</p>` at line ~147) to a CWS install button at the supplied URL — branch, commit, PR, merge
 3. Tag the released commit: `git tag vX.Y.Z-published && git push origin vX.Y.Z-published`
 4. Comment on #95 with the approval date and the live URL; close the issue
 
-### 12b. Operator does (clean-profile smoke test)
+### 15b. Operator does (clean-profile smoke test)
 
 1. Install Clio from the CWS listing on a clean Chrome profile (agent cannot drive Chrome's profile manager)
 2. **Gemini smoke test:** open a Gemini conversation → click the Clio toolbar icon → click Extract → verify a valid ZIP downloads and the JSON parses
@@ -366,11 +444,11 @@ After Chrome approves the listing and emails the operator that the version is li
 4. **ChatGPT smoke test:** repeat on a ChatGPT conversation
 5. Verify `chrome://extensions` shows the version that was uploaded
 
-### 12c. If a smoke test fails
+### 15c. If a smoke test fails
 
 Do **not** delist. File a `launch-blocker` issue, reproduce in dev mode, ship a patch version. A version on the store that mostly works is recoverable; a removed listing has to go through review from scratch.
 
-## 13. Version bump procedure
+## 16. Version bump procedure
 
 When preparing a new release:
 
@@ -381,7 +459,7 @@ When preparing a new release:
 5. Merge to `main`
 6. Then follow §4 Build and §5 or §6 Upload above
 
-## 14. Troubleshooting
+## 17. Troubleshooting
 
 | Problem | Diagnosis | Action |
 |---------|-----------|--------|
@@ -391,9 +469,10 @@ When preparing a new release:
 | ZIP contains unexpected files | Stray dev artifacts under `extensions/` | Locate and remove; verify `extensions/` is only extension files before re-zipping |
 | Privacy Policy URL "not reachable" | Domain or page down | Verify `https://cliocast.com/privacy` resolves with HTTP 200 in a fresh browser before re-submitting |
 | Manifest validation fails on icon dimensions | Missing 32px or asymmetric dimensions | Check `icons/` for all four sizes; regenerate if needed (see `docs/design/icon_prompts.md`) |
+| Screenshot rejected with alpha-channel error | PNG has RGBA, not RGB | Re-export as 24-bit PNG (no alpha) — `tools/resize_screenshot.py` can re-save; or use ImageMagick `convert in.png -background black -alpha remove -alpha off out.png` |
 | Avatar shows wrong account at dashboard | Multi-account hazard | Sign out fully, close Chrome, re-open, choose `cto@thrivetech.ai` from picker; full diagnostic in [`30004-cws-account-setup.md`](./30004-cws-account-setup.md) |
 
-## 15. Release notes
+## 18. Release notes
 
 Per-version release notes live in `docs/releases/` with the naming convention:
 
@@ -410,7 +489,7 @@ Create the release notes file **before** §4 Build — it serves as the source o
 Current per-version files in this repo:
 - [`docs/releases/chrome-v1.4.1.md`](../releases/chrome-v1.4.1.md) — v1.4.1 (first submitted version)
 
-## 16. Related documents
+## 19. Related documents
 
 - [`30001-development-runbook.md`](./30001-development-runbook.md) — dev-mode setup, test workflow, versioning policy
 - [`30003-cloudflare-pages-setup.md`](./30003-cloudflare-pages-setup.md) — CFP setup for cliocast.com
@@ -420,10 +499,11 @@ Current per-version files in this repo:
 - `SECURITY.md` — threat model and vulnerability reporting
 - `extensions/manifest.json` — ground-truth permission declaration
 
-## 17. Change log
+## 20. Change log
 
 | Version | Date | Change |
 |---------|------|--------|
+| 8 | 2026-05-28 3:45:01 PM Central | Added three missing Store-listing tab sections in dashboard order: new §8 Graphic assets (store icon, promo video, screenshots, promo tiles); new §9 Additional fields (official URL, homepage URL, support URL, mature content); new §10 Item support (visibility toggle). All downstream sections renumbered: §8 Privacy → §11, §9 Permissions → §12, §10 Pricing → §13, §11 Submit → §14, §12 Post-publish → §15, §13 Version bump → §16, §14 Troubleshooting → §17, §15 Release notes → §18, §16 Related docs → §19, §17 Change log → §20. §0 invoke table updated: post-publish row references §15a (was §12a). §1 Reading paths expanded to include §8–§13 on Path A; Path B reframed to "review §7–§13 if listing copy changed." §3a.2 references §12 (was §9). §3a.10 references §18 (was §15). §3a.11 specifies 24-bit PNG no alpha (matches CWS requirement) and adds color-mode verification (RGB not RGBA). §3b.4 expanded to "§7 through §12 paste-blocks." §7 renamed `Store listing` → `Store listing — product details` to mirror §8/§9/§10's `Store listing — <subsection>` framing. §5 updated to point at §7 → §8 → §9 → §10 sequence. §17 Troubleshooting gains a row for screenshot alpha-channel rejection. Closes #182. |
 | 7 | 2026-05-28 3:40:27 PM Central | §7d Category corrected: `Productivity` is a CWS meta-header (not selectable). Paste-block changed to `Tools`. Added preamble explaining the meta-header structure and a rationale list naming each rejected option and why, so the choice survives future maintainers. Closes #180. |
 | 6 | 2026-05-28 3:26:11 PM Central | §4 restructured for symmetry with §3. Renamed `Build the ZIP` → `Build & verify the ZIP`. New §4a Build (the build_release.py invocation + fallback). Existing §4a Verify renumbered to §4b Verify. Both substeps carry the `(agent does this)` label explicitly. §0 invoke-table updated: `Run §4` triggers build + verify, not "build only". Closes #178. |
 | 5 | 2026-05-28 3:23:56 PM Central | §7c Long Description gets new "IF CLIO HELPS YOU" closing section asking for a Chrome Web Store review or GitHub star. Framed as "help others discover this useful extension" — not begging-tone. Closes #175. |


### PR DESCRIPTION
## Summary

Three Store-listing-tab sections the operator hit on the live CWS form that v7 didn't cover. Inserted in dashboard order between current §7 and what was §8 Privacy; downstream sections renumbered through §20. Cross-references updated throughout.

New sections are paste-ready: file paths, dimension/format requirements, default values, and rationale for choices that survive the operator's session.

Closes #182