### PR TITLE
feat(storage): IndexedDB archive store + download ledger (Closes #48)

### DIFF
--- a/extensions/src/storage/db.js
+++ b/extensions/src/storage/db.js
@@ -1,0 +1,239 @@
+/* global indexedDB */
+// Clio 2.0 — local archive store (#48).
+//
+// IndexedDB-backed persistence for the batch-download feature: the catalog of
+// conversations, the extraction/download queue, harvest-run records, per-account
+// labels, and settings. This is the "database of what you downloaded" — it lets
+// the batch walk resume, skip already-downloaded conversations, and report
+// progress.
+//
+// Promise-based API; works in the extension (real `indexedDB`) and under Jest
+// (fake-indexeddb). No third-party runtime deps.
+
+const DB_NAME = 'clio-archive';
+const DB_VERSION = 1;
+
+// Object stores and their key configuration.
+const STORES = {
+  accounts: { keyPath: 'account_label' },
+  conversations: { keyPath: ['site', 'account_label', 'conversation_id'] },
+  harvest_runs: { keyPath: 'run_id', autoIncrement: true },
+  extraction_queue: { keyPath: 'conversation_key' },
+  settings: { keyPath: 'key' },
+};
+
+let _dbPromise = null;
+
+// ---------------------------------------------------------------------------
+// Low-level helpers
+// ---------------------------------------------------------------------------
+
+/** Open (and migrate) the database. Cached after first call. */
+function openDb() {
+  if (_dbPromise) return _dbPromise;
+  _dbPromise = new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = (event) => {
+      const db = event.target.result;
+      for (const [name, opts] of Object.entries(STORES)) {
+        if (db.objectStoreNames.contains(name)) continue;
+        const store = db.createObjectStore(name, opts);
+        if (name === 'conversations') {
+          store.createIndex('by_download_status', 'download_status', { unique: false });
+        }
+        if (name === 'extraction_queue') {
+          store.createIndex('by_status', 'status', { unique: false });
+        }
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+  return _dbPromise;
+}
+
+/** Reset the cached connection (tests / re-init). */
+function _resetDbCache() {
+  _dbPromise = null;
+}
+
+/** Wrap an IDBRequest as a Promise. */
+function _await(request) {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/** Run `fn(store)` inside a transaction and resolve when it commits. */
+async function _withStore(name, mode, fn) {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(name, mode);
+    const store = transaction.objectStore(name);
+    let result;
+    Promise.resolve(fn(store)).then((r) => { result = r; }).catch(reject);
+    transaction.oncomplete = () => resolve(result);
+    transaction.onerror = () => reject(transaction.error);
+    transaction.onabort = () => reject(transaction.error);
+  });
+}
+
+const _put = (name, value) => _withStore(name, 'readwrite', (s) => _await(s.put(value)));
+const _get = (name, key) => _withStore(name, 'readonly', (s) => _await(s.get(key)));
+const _getAll = (name) => _withStore(name, 'readonly', (s) => _await(s.getAll()));
+
+// Composite conversation key <-> flat string key (used by extraction_queue).
+const convKey = ({ site, account_label, conversation_id }) => [site, account_label, conversation_id];
+const flatKey = ({ site, account_label, conversation_id }) => `${site}::${account_label}::${conversation_id}`;
+
+// ---------------------------------------------------------------------------
+// Accounts (#48 / F3)
+// ---------------------------------------------------------------------------
+
+const upsertAccount = ({ account_label, site }) =>
+  _put('accounts', { account_label, site, created_at: new Date().toISOString() });
+const listAccounts = () => _getAll('accounts');
+
+// ---------------------------------------------------------------------------
+// Conversations catalog + download ledger
+// ---------------------------------------------------------------------------
+
+/** Insert or update a conversation row. Preserves download state on re-harvest. */
+async function upsertConversation(row) {
+  const existing = await _get('conversations', convKey(row));
+  const merged = {
+    site: row.site,
+    account_label: row.account_label,
+    conversation_id: row.conversation_id,
+    title: row.title ?? existing?.title ?? '',
+    url: row.url ?? existing?.url ?? null,
+    list_position: row.list_position ?? existing?.list_position ?? null,
+    updated_at: row.updated_at ?? existing?.updated_at ?? null,
+    harvested_at: new Date().toISOString(),
+    // Download-ledger fields (never clobbered by a metadata re-harvest):
+    download_status: existing?.download_status ?? 'pending',
+    downloaded_at: existing?.downloaded_at ?? null,
+    zip_name: existing?.zip_name ?? null,
+    download_error: existing?.download_error ?? null,
+  };
+  await _put('conversations', merged);
+  return merged;
+}
+
+const getConversation = (keyObj) => _get('conversations', convKey(keyObj));
+
+/** List conversations, optionally filtered by site / account_label / download_status. */
+async function listConversations(filter = {}) {
+  const all = await _getAll('conversations');
+  return all.filter((c) =>
+    (filter.site === undefined || c.site === filter.site) &&
+    (filter.account_label === undefined || c.account_label === filter.account_label) &&
+    (filter.download_status === undefined || c.download_status === filter.download_status));
+}
+
+/** Mark a conversation downloaded (ledger success) and complete its queue row. */
+async function markDownloaded(keyObj, { zip_name } = {}) {
+  const conv = await _get('conversations', convKey(keyObj));
+  if (conv) {
+    conv.download_status = 'done';
+    conv.downloaded_at = new Date().toISOString();
+    conv.zip_name = zip_name ?? conv.zip_name;
+    conv.download_error = null;
+    await _put('conversations', conv);
+  }
+  await _setQueueStatus(keyObj, 'done');
+}
+
+/** Mark a conversation's download failed (ledger error) and flag its queue row. */
+async function markDownloadError(keyObj, error) {
+  const conv = await _get('conversations', convKey(keyObj));
+  if (conv) {
+    conv.download_status = 'error';
+    conv.download_error = String(error).slice(0, 500);
+    await _put('conversations', conv);
+  }
+  const q = await _get('extraction_queue', flatKey(keyObj));
+  await _put('extraction_queue', {
+    conversation_key: flatKey(keyObj),
+    ...keyObj,
+    status: 'error',
+    attempts: (q?.attempts ?? 0) + 1,
+    last_error: String(error).slice(0, 500),
+    enqueued_at: q?.enqueued_at ?? new Date().toISOString(),
+  });
+}
+
+/** Aggregate download progress counts (for the #63 progress UI). */
+async function statusCounts(filter = {}) {
+  const rows = await listConversations(filter);
+  return rows.reduce((acc, c) => {
+    acc.total += 1;
+    acc[c.download_status] = (acc[c.download_status] || 0) + 1;
+    return acc;
+  }, { total: 0, pending: 0, done: 0, error: 0 });
+}
+
+// ---------------------------------------------------------------------------
+// Extraction / download queue (#60 worker consumes this)
+// ---------------------------------------------------------------------------
+
+/** Enqueue a conversation for extraction (idempotent; skips already-done rows). */
+async function enqueueExtraction(keyObj) {
+  const key = flatKey(keyObj);
+  const existing = await _get('extraction_queue', key);
+  if (existing && existing.status === 'done') return existing;
+  const row = {
+    conversation_key: key,
+    site: keyObj.site,
+    account_label: keyObj.account_label,
+    conversation_id: keyObj.conversation_id,
+    status: 'pending',
+    attempts: existing?.attempts ?? 0,
+    last_error: null,
+    enqueued_at: existing?.enqueued_at ?? new Date().toISOString(),
+  };
+  await _put('extraction_queue', row);
+  return row;
+}
+
+async function _setQueueStatus(keyObj, status) {
+  const key = flatKey(keyObj);
+  const row = await _get('extraction_queue', key);
+  if (!row) return;
+  row.status = status;
+  await _put('extraction_queue', row);
+}
+
+/** Claim the next pending queue row (marks it in_progress) or null if none. */
+async function dequeueNext() {
+  const all = await _getAll('extraction_queue');
+  const next = all.find((r) => r.status === 'pending');
+  if (!next) return null;
+  next.status = 'in_progress';
+  await _put('extraction_queue', next);
+  return next;
+}
+
+// ---------------------------------------------------------------------------
+// Harvest runs + settings
+// ---------------------------------------------------------------------------
+
+/** Record a harvest run; returns the auto-assigned run_id. */
+const recordRun = (run) =>
+  _withStore('harvest_runs', 'readwrite', (s) => _await(s.add({ ...run, recorded_at: new Date().toISOString() })));
+
+const getSetting = async (key) => (await _get('settings', key))?.value;
+const setSetting = (key, value) => _put('settings', { key, value });
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    DB_NAME, DB_VERSION, STORES,
+    openDb, _resetDbCache, convKey, flatKey,
+    upsertAccount, listAccounts,
+    upsertConversation, getConversation, listConversations,
+    markDownloaded, markDownloadError, statusCounts,
+    enqueueExtraction, dequeueNext,
+    recordRun, getSetting, setSetting,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,11 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.40.0",
+        "fake-indexeddb": "^6.2.5",
         "jest": "^29.7.0",
-        "jest-environment-jsdom": "^29.7.0"
+        "jest-environment-jsdom": "^29.7.0",
+        "playwright-extra": "^4.3.6",
+        "puppeteer-extra-plugin-stealth": "^2.11.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -980,6 +983,16 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -1028,6 +1041,13 @@
         "@types/tough-cookie": "*",
         "parse5": "^7.0.0"
       }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.0.9",
@@ -1192,6 +1212,16 @@
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/asynckit": {
@@ -1527,6 +1557,23 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clone-deep": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+      "integrity": "sha512-we+NuQo2DHhSl+DP6jlUiAhyAjBQrYnpOk15rN6c6JSPScjiCLh8IbSU+VTcph6YS3o7mASE8a0+gbZ7ChLpgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "for-own": "^0.1.3",
+        "is-plain-object": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "lazy-cache": "^1.0.3",
+        "shallow-clone": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/co": {
@@ -2013,6 +2060,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2057,6 +2114,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "for-in": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -2072,6 +2152,31 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fs-extra/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -2415,6 +2520,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -2429,6 +2541,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -2459,6 +2581,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -2493,6 +2628,16 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -3302,6 +3447,29 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonfile/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/jszip": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -3314,6 +3482,19 @@
         "setimmediate": "^1.0.5"
       }
     },
+    "node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -3322,6 +3503,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/leven": {
@@ -3422,6 +3613,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/merge-deep": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.3.tgz",
+      "integrity": "sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "clone-deep": "^0.2.4",
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -3487,6 +3693,30 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/mixin-object": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+      "integrity": "sha512-ALGF1Jt9ouehcaXaHhn6t1yGWRqGaHkPFndtFVHfZXOvkIZ/yoGaSi0AHVTafb3ZBGg4dr/bDwnaEKqCXzchMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "for-in": "^0.1.3",
+        "is-extendable": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mixin-object/node_modules/for-in": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+      "integrity": "sha512-F0to7vbBSHP8E3l6dCjxNOLuSFAACIxFy3UehTUlG7svlXi37HHsDkyVcHo0Pq8QwrE+pXvWSVX3ZT1T9wAZ9g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ms": {
@@ -3778,6 +4008,31 @@
         "node": ">=18"
       }
     },
+    "node_modules/playwright-extra": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/playwright-extra/-/playwright-extra-4.3.6.tgz",
+      "integrity": "sha512-q2rVtcE8V8K3vPVF1zny4pvwZveHLH8KBuVU2MoE3Jw4OKVoBWsHI9CH9zPydovHHOCDxjGN2Vg+2m644q3ijA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "playwright": "*",
+        "playwright-core": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": true
+        },
+        "playwright-core": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/playwright/node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -3862,6 +4117,116 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer-extra-plugin": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin/-/puppeteer-extra-plugin-3.2.3.tgz",
+      "integrity": "sha512-6RNy0e6pH8vaS3akPIKGg28xcryKscczt4wIl0ePciZENGE2yoaQJNd17UiEbdmh5/6WW6dPcfRWT9lxBwCi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.1.0",
+        "debug": "^4.1.1",
+        "merge-deep": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=9.11.2"
+      },
+      "peerDependencies": {
+        "playwright-extra": "*",
+        "puppeteer-extra": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright-extra": {
+          "optional": true
+        },
+        "puppeteer-extra": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer-extra-plugin-stealth": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-stealth/-/puppeteer-extra-plugin-stealth-2.11.2.tgz",
+      "integrity": "sha512-bUemM5XmTj9i2ZerBzsk2AN5is0wHMNE6K0hXBzBXOzP5m5G3Wl0RHhiqKeHToe/uIH8AoZiGhc1tCkLZQPKTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "puppeteer-extra-plugin": "^3.2.3",
+        "puppeteer-extra-plugin-user-preferences": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "playwright-extra": "*",
+        "puppeteer-extra": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright-extra": {
+          "optional": true
+        },
+        "puppeteer-extra": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer-extra-plugin-user-data-dir": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-user-data-dir/-/puppeteer-extra-plugin-user-data-dir-2.4.1.tgz",
+      "integrity": "sha512-kH1GnCcqEDoBXO7epAse4TBPJh9tEpVEK/vkedKfjOVOhZAvLkHGc9swMs5ChrJbRnf8Hdpug6TJlEuimXNQ+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^10.0.0",
+        "puppeteer-extra-plugin": "^3.2.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "playwright-extra": "*",
+        "puppeteer-extra": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright-extra": {
+          "optional": true
+        },
+        "puppeteer-extra": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer-extra-plugin-user-preferences": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-user-preferences/-/puppeteer-extra-plugin-user-preferences-2.4.1.tgz",
+      "integrity": "sha512-i1oAZxRbc1bk8MZufKCruCEC3CCafO9RKMkkodZltI4OqibLFXF3tj6HZ4LZ9C5vCXZjYcDWazgtY69mnmrQ9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "deepmerge": "^4.2.2",
+        "puppeteer-extra-plugin": "^3.2.3",
+        "puppeteer-extra-plugin-user-data-dir": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "playwright-extra": "*",
+        "puppeteer-extra": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright-extra": {
+          "optional": true
+        },
+        "puppeteer-extra": {
+          "optional": true
+        }
       }
     },
     "node_modules/pure-rand": {
@@ -3981,6 +4346,23 @@
         "node": ">=10"
       }
     },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -4022,6 +4404,45 @@
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
+    },
+    "node_modules/shallow-clone": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
+      "integrity": "sha512-J1zdXCky5GmNnuauESROVu31MQSnLoYvlyEn6j2Ztk6Q5EHFIhxkMhYcv6vuDzl2XEzoRr856QwzMgWM/TmZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.1",
+        "kind-of": "^2.0.1",
+        "lazy-cache": "^0.2.3",
+        "mixin-object": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shallow-clone/node_modules/kind-of": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+      "integrity": "sha512-0u8i1NZ/mg0b+W3MGGw5I7+6Eib2nx72S/QvXa0hYjEkjTknYmEYQJwGu3mLC0BrhtJjtQafTkyRUQ75Kx0LVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shallow-clone/node_modules/lazy-cache": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+      "integrity": "sha512-gkX52wvU/R8DVMMt78ATVPFMJqfW8FPz1GZ1sVHBVQHmu/WvhIWE4cE1GBzhJNFicDeYhnwp6Rl35BcAIM3YOQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,11 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.40.0",
+    "fake-indexeddb": "^6.2.5",
     "jest": "^29.7.0",
-    "jest-environment-jsdom": "^29.7.0"
+    "jest-environment-jsdom": "^29.7.0",
+    "playwright-extra": "^4.3.6",
+    "puppeteer-extra-plugin-stealth": "^2.11.2"
   },
   "dependencies": {
     "jszip": "^3.10.1"

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment node
+ */
+// Storage / ledger tests (#48) — real IndexedDB behavior via fake-indexeddb.
+// Runs in the Node environment (has structuredClone, which fake-indexeddb needs;
+// jsdom does not). No DOM is required for storage.
+require('fake-indexeddb/auto');
+const { IDBFactory } = require('fake-indexeddb');
+const db = require('../extensions/src/storage/db.js');
+
+const K = { site: 'claude', account_label: 'personal', conversation_id: 'abc123' };
+const K2 = { site: 'claude', account_label: 'personal', conversation_id: 'def456' };
+
+beforeEach(() => {
+  // Fresh, empty database for every test.
+  globalThis.indexedDB = new IDBFactory();
+  db._resetDbCache();
+});
+
+describe('schema', () => {
+  test('openDb creates all five object stores', async () => {
+    const conn = await db.openDb();
+    expect(Array.from(conn.objectStoreNames).sort()).toEqual([
+      'accounts', 'conversations', 'extraction_queue', 'harvest_runs', 'settings',
+    ]);
+  });
+});
+
+describe('conversations catalog + download ledger', () => {
+  test('upsert then get round-trips, defaults to pending', async () => {
+    await db.upsertConversation({ ...K, title: 'Hello', url: '/chat/abc123' });
+    const got = await db.getConversation(K);
+    expect(got.title).toBe('Hello');
+    expect(got.url).toBe('/chat/abc123');
+    expect(got.download_status).toBe('pending');
+  });
+
+  test('re-harvest updates metadata but PRESERVES download state (resume-safe)', async () => {
+    await db.upsertConversation({ ...K, title: 'Hello' });
+    await db.markDownloaded(K, { zip_name: 'abc.zip' });
+    // A later metadata-only harvest must not undo the download.
+    await db.upsertConversation({ ...K, title: 'Hello (renamed)' });
+    const got = await db.getConversation(K);
+    expect(got.title).toBe('Hello (renamed)');
+    expect(got.download_status).toBe('done');
+    expect(got.zip_name).toBe('abc.zip');
+  });
+
+  test('listConversations filters by download_status', async () => {
+    await db.upsertConversation({ ...K, title: 'A' });
+    await db.upsertConversation({ ...K2, title: 'B' });
+    await db.markDownloaded(K, { zip_name: 'a.zip' });
+    const done = await db.listConversations({ download_status: 'done' });
+    const pending = await db.listConversations({ download_status: 'pending' });
+    expect(done.map((c) => c.conversation_id)).toEqual(['abc123']);
+    expect(pending.map((c) => c.conversation_id)).toEqual(['def456']);
+  });
+
+  test('statusCounts aggregates progress', async () => {
+    await db.upsertConversation({ ...K, title: 'A' });
+    await db.upsertConversation({ ...K2, title: 'B' });
+    await db.markDownloaded(K, { zip_name: 'a.zip' });
+    expect(await db.statusCounts()).toMatchObject({ total: 2, done: 1, pending: 1 });
+  });
+
+  test('markDownloadError flags conversation as error', async () => {
+    await db.upsertConversation({ ...K, title: 'A' });
+    await db.enqueueExtraction(K);
+    await db.markDownloadError(K, 'boom');
+    const conv = await db.getConversation(K);
+    expect(conv.download_status).toBe('error');
+    expect(conv.download_error).toBe('boom');
+  });
+});
+
+describe('extraction / download queue', () => {
+  test('enqueue then dequeue claims the row (in_progress)', async () => {
+    await db.enqueueExtraction(K);
+    const row = await db.dequeueNext();
+    expect(row.conversation_id).toBe('abc123');
+    expect(row.status).toBe('in_progress');
+    expect(await db.dequeueNext()).toBeNull(); // nothing pending remains
+  });
+
+  test('enqueue is idempotent and never re-queues a done conversation', async () => {
+    await db.upsertConversation({ ...K, title: 'A' });
+    await db.enqueueExtraction(K);
+    await db.markDownloaded(K, { zip_name: 'a.zip' }); // completes the queue row
+    const again = await db.enqueueExtraction(K);
+    expect(again.status).toBe('done'); // stays done, not reset to pending
+  });
+});
+
+describe('harvest runs + settings', () => {
+  test('recordRun returns an auto-assigned id', async () => {
+    const id = await db.recordRun({ site: 'claude', account_label: 'personal', conversations_found: 223 });
+    expect(id).toBeGreaterThan(0);
+  });
+
+  test('settings round-trip', async () => {
+    await db.setSetting('rate_ms', 400);
+    expect(await db.getSetting('rate_ms')).toBe(400);
+    expect(await db.getSetting('missing')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Adds `extensions/src/storage/db.js` — the local archive/ledger the in-extension batch-download feature reads to **resume**, **skip already-downloaded conversations**, and **report progress**. This is the "database of what you downloaded."

- Five IndexedDB object stores: `accounts`, `conversations`, `harvest_runs`, `extraction_queue`, `settings`.
- Promise API: `openDb`, `upsertConversation`, `getConversation`, `listConversations`, `enqueueExtraction`, `dequeueNext`, `markDownloaded`, `markDownloadError`, `statusCounts`, `recordRun`, `get/setSetting`.
- Versioned schema via `onupgradeneeded`.
- **Resume-safe:** a metadata re-harvest updates title/url but never clobbers download state (`download_status`, `zip_name`, `downloaded_at`).

The module is not yet wired into `manifest.json` (inert until the enumerate/worker/UI pieces land), so the shipped extension's behavior is unchanged — no version bump.

## Tests

`tests/storage.test.js` — 10 tests against real IndexedDB via `fake-indexeddb` (new devDependency), run in the node environment (jsdom lacks `structuredClone`). Full suite: **304 passing**.

## Note

`package.json` / `package-lock.json` also persist two already-installed operator devDeps (`playwright-extra`, `puppeteer-extra-plugin-stealth`, used by the e2e discovery tooling) that couldn't be separated from the `fake-indexeddb` declaration without disturbing uncommitted working-tree state.

Closes #48
