### PR TITLE
feat(extension): Download All Conversations — enumerate + walk + progress UI (Closes #54, #60, #63)

### DIFF
--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Clio",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Extract full Gemini, Claude, and ChatGPT conversations to JSON with images",
   "permissions": [
     "activeTab",

--- a/extensions/src/archive-page.js
+++ b/extensions/src/archive-page.js
@@ -1,0 +1,129 @@
+/* global chrome, openDb, statusCounts, seedQueue, runBatch */
+// Clio 2.0 — Download-All page orchestrator (#63 + wiring).
+//
+// Opens one background "worker tab" on the site, enumerates the full conversation
+// list in it (scroll-until-stable, via enumerate.js injected with chrome.scripting),
+// seeds the ledger queue, then runs the batch worker (archive.js) which drives the
+// same tab through each conversation. Live progress + pause / resume / cancel.
+
+const params = new URLSearchParams(location.search);
+const SITE = params.get('site') || 'claude';
+const ACCOUNT = params.get('account') || 'default';
+const SITE_BASE = {
+  claude: 'https://claude.ai/',
+  gemini: 'https://gemini.google.com/app',
+  chatgpt: 'https://chatgpt.com/',
+}[SITE] || 'https://claude.ai/';
+
+const control = { paused: false, cancelled: false };
+const $ = (id) => document.getElementById(id);
+const setPhase = (t) => { $('phase').textContent = t; };
+
+function log(msg, cls) {
+  const line = document.createElement('div');
+  if (cls) line.className = cls;
+  line.textContent = msg;
+  $('log').insertBefore(line, $('log').firstChild);
+}
+
+function render(counts, last) {
+  const total = counts.total || 0;
+  $('bar').max = total || 1;
+  $('bar').value = (counts.done || 0) + (counts.error || 0);
+  $('counts').innerHTML =
+    `<b>${counts.done || 0}</b> downloaded · <b>${counts.error || 0}</b> failed · <b>${counts.pending || 0}</b> left (of ${total})`;
+  if (last && last.conv) {
+    const t = last.conv.title || last.conv.conversation_id;
+    $('current').textContent = `Last: ${t}`;
+    log(`${last.result.ok ? 'OK ' : 'XX '} ${t}`, last.result.ok ? 'ok' : 'xx');
+  }
+}
+
+function tabComplete(tabId) {
+  return new Promise((resolve) => {
+    function listener(id, info) {
+      if (id === tabId && info.status === 'complete') {
+        chrome.tabs.onUpdated.removeListener(listener);
+        resolve();
+      }
+    }
+    chrome.tabs.onUpdated.addListener(listener);
+  });
+}
+
+async function ensureWorkerTab() {
+  const tab = await chrome.tabs.create({ url: SITE_BASE, active: false }); // background; user watches this page
+  await tabComplete(tab.id);
+  await new Promise((r) => setTimeout(r, 3000)); // let the app hydrate
+  return tab.id;
+}
+
+async function enumerateInTab(tabId) {
+  // Best-effort: open + pin the sidebar so the full list is present + scrollable (Claude).
+  await chrome.scripting.executeScript({
+    target: { tabId },
+    func: () => {
+      for (const sel of ['button[aria-label="Open sidebar"]', '[data-testid="pin-sidebar-toggle"]']) {
+        const el = document.querySelector(sel);
+        if (el) el.click();
+      }
+    },
+  }).catch(() => {});
+  await new Promise((r) => setTimeout(r, 1200));
+
+  // Inject the enumerator and run scroll-until-stable inside the tab.
+  await chrome.scripting.executeScript({ target: { tabId }, files: ['src/enumerate.js'] });
+  const [{ result }] = await chrome.scripting.executeScript({
+    target: { tabId },
+    func: (site) => window.enumerateAll(site),
+    args: [SITE],
+  });
+  return result || [];
+}
+
+async function main() {
+  $('site').textContent = `Site: ${SITE} · account: ${ACCOUNT}`;
+  $('pauseBtn').onclick = () => {
+    control.paused = !control.paused;
+    $('pauseBtn').textContent = control.paused ? 'Resume' : 'Pause';
+    setPhase(control.paused ? 'Paused' : 'Walking & downloading…');
+  };
+  $('cancelBtn').onclick = () => { control.cancelled = true; setPhase('Cancelling…'); };
+
+  await openDb();
+
+  setPhase('Opening a worker tab…');
+  const tabId = await ensureWorkerTab();
+
+  setPhase('Enumerating conversations (scrolling the list)…');
+  const convs = await enumerateInTab(tabId);
+  log(`Enumerated ${convs.length} conversations.`);
+  if (!convs.length) {
+    setPhase('No conversations found — make sure you are logged in and the sidebar is visible, then reload.');
+    return;
+  }
+
+  await seedQueue(convs, SITE, ACCOUNT);
+  render(await statusCounts({ site: SITE, account_label: ACCOUNT }));
+
+  setPhase('Walking & downloading…');
+  const res = await runBatch({
+    tabId,
+    paceMs: 800,
+    isPaused: () => control.paused,
+    isCancelled: () => control.cancelled,
+    onProgress: (counts, last) => render(counts, last),
+  });
+
+  render(await statusCounts({ site: SITE, account_label: ACCOUNT }));
+  setPhase(control.cancelled
+    ? `Cancelled — ${res.done} downloaded, ${res.failed} failed.`
+    : `Done — ${res.done} downloaded, ${res.failed} failed.`);
+  log(`FINISHED: ${res.done} downloaded, ${res.failed} failed.`);
+  $('pauseBtn').disabled = true;
+}
+
+main().catch((e) => {
+  setPhase('Error: ' + (e.message || e));
+  log('FATAL ' + (e.message || e), 'xx');
+});

--- a/extensions/src/archive.html
+++ b/extensions/src/archive.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Clio — Download All Conversations</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      margin: 0; padding: 24px; max-width: 820px; margin: 0 auto;
+      color: #1a1a1a; background: #fafafa;
+    }
+    h1 { font-size: 20px; margin: 0 0 4px; }
+    .sub { color: #666; font-size: 13px; margin-bottom: 20px; }
+    .card { background: #fff; border: 1px solid #e5e5e5; border-radius: 10px; padding: 18px; margin-bottom: 16px; }
+    #phase { font-size: 15px; font-weight: 600; margin-bottom: 10px; }
+    progress { width: 100%; height: 14px; border-radius: 7px; }
+    #counts { font-size: 14px; margin-top: 10px; }
+    #counts b { font-variant-numeric: tabular-nums; }
+    #current { font-size: 13px; color: #444; margin-top: 8px; min-height: 18px; }
+    .controls { display: flex; gap: 10px; margin-top: 16px; }
+    button {
+      font-size: 14px; padding: 8px 18px; border-radius: 8px; border: 1px solid #ccc;
+      background: #fff; cursor: pointer;
+    }
+    button:hover { background: #f0f0f0; }
+    button#cancelBtn { border-color: #e0b4b4; color: #a33; }
+    #log {
+      font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+      font-size: 12px; line-height: 1.5; max-height: 360px; overflow-y: auto;
+      background: #1e1e1e; color: #d4d4d4; border-radius: 8px; padding: 12px; white-space: pre-wrap;
+    }
+    .ok { color: #6a9955; } .xx { color: #e07a7a; }
+    .note { font-size: 12px; color: #888; margin-top: 6px; }
+  </style>
+</head>
+<body>
+  <h1>Clio — Download All Conversations</h1>
+  <div class="sub" id="site">…</div>
+
+  <div class="card">
+    <div id="phase">Starting…</div>
+    <progress id="bar" max="1" value="0"></progress>
+    <div id="counts"><b>0</b> downloaded · <b>0</b> failed · <b>0</b> left</div>
+    <div id="current"></div>
+    <div class="controls">
+      <button id="pauseBtn">Pause</button>
+      <button id="cancelBtn">Cancel</button>
+    </div>
+    <div class="note">Keep this tab open until it finishes. It walks each conversation, extracts it with Clio's normal extractor, and downloads one ZIP per conversation. Already-downloaded conversations are skipped, so you can safely stop and resume.</div>
+  </div>
+
+  <div id="log"></div>
+
+  <script src="../lib/jszip.min.js"></script>
+  <script src="storage/db.js"></script>
+  <script src="enumerate.js"></script>
+  <script src="archive.js"></script>
+  <script src="archive-page.js"></script>
+</body>
+</html>

--- a/extensions/src/archive.js
+++ b/extensions/src/archive.js
@@ -59,14 +59,32 @@ function sendExtract(tabId) {
   });
 }
 
+// The per-site content scripts, for re-injection when a navigation drops them.
+const CONTENT_SCRIPTS = {
+  gemini: ['src/selectors.js', 'src/content.js'],
+  claude: ['src/selectors-claude.js', 'src/content.js'],
+  chatgpt: ['src/selectors-chatgpt.js', 'src/content.js'],
+};
+const scriptsForSite = (site) => CONTENT_SCRIPTS[site] || CONTENT_SCRIPTS.claude;
+
 /** Navigate the worker tab to a conversation and run the existing extractor. */
-async function navigateAndExtract(tabId, url) {
+async function navigateAndExtract(tabId, url, site) {
   await chrome.tabs.update(tabId, { url });
   await waitForTabComplete(tabId);
   await sleep(1500); // let the SPA render + lazy content settle
-  const resp = await sendExtract(tabId);
-  if (!resp || !resp.success) throw new Error((resp && resp.error) || 'extraction failed');
-  return resp; // { success, data, images, warnings } — Clio's existing shape
+  try {
+    const resp = await sendExtract(tabId);
+    if (!resp || !resp.success) throw new Error((resp && resp.error) || 'extraction failed');
+    return resp; // { success, data, images, warnings } — Clio's existing shape
+  } catch (err) {
+    // The content script may not be present after a fresh navigation — inject it and retry once.
+    if (!/receiving end|Could not establish/i.test(err.message || '')) throw err;
+    await chrome.scripting.executeScript({ target: { tabId }, files: scriptsForSite(site) });
+    await sleep(800);
+    const resp = await sendExtract(tabId);
+    if (!resp || !resp.success) throw new Error((resp && resp.error) || 'extraction failed after reinject');
+    return resp;
+  }
 }
 
 /** Build the current-design ZIP (mirrors popup.js createZip). */
@@ -110,7 +128,7 @@ async function processOne(tabId, conv, deps = DEFAULT_DEPS) {
     conversation_id: conv.conversation_id,
   };
   try {
-    const resp = await deps.navigateAndExtract(tabId, conv.url);
+    const resp = await deps.navigateAndExtract(tabId, conv.url, conv.site);
     const blob = await deps.buildZip(resp.data, resp.images);
     const filename = zipName(conv, resp.data);
     await deps.downloadZip(blob, filename);
@@ -148,9 +166,20 @@ async function runBatch(control, deps = DEFAULT_DEPS) {
   return { done, failed };
 }
 
+/** Seed the ledger + queue from an enumerated conversation list (idempotent). */
+async function seedQueue(convs, site, account_label) {
+  let queued = 0;
+  for (const c of convs) {
+    await upsertConversation({ site, account_label, conversation_id: c.conversation_id, title: c.title, url: c.url });
+    await enqueueExtraction({ site, account_label, conversation_id: c.conversation_id });
+    queued += 1;
+  }
+  return { enumerated: convs.length, queued };
+}
+
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
     zipName, sanitize, buildZip, navigateAndExtract, waitForTabComplete, sendExtract,
-    downloadZip, processOne, runBatch, DEFAULT_DEPS,
+    downloadZip, processOne, runBatch, seedQueue, scriptsForSite, CONTENT_SCRIPTS, DEFAULT_DEPS,
   };
 }

--- a/extensions/src/archive.js
+++ b/extensions/src/archive.js
@@ -1,0 +1,156 @@
+/* global chrome, JSZip, getConversation, markDownloaded, markDownloadError, dequeueNext, statusCounts, sleepImpl */
+// Clio 2.0 — batch-download worker (#60).
+//
+// The walk: for each queued conversation, navigate a worker tab to the
+// conversation, run Clio's EXISTING DOM extractor (the same `{action:'extract'}`
+// the single-conversation button uses — it renders the page, so it captures
+// artifacts/documents the way the site API cannot), build the current-design
+// ZIP (conversation.json + images/), download it, and record the result in the
+// ledger (extensions/src/storage/db.js). Crash-resumable via the ledger.
+//
+// The loop (`runBatch`) and per-conversation step (`processOne`) take injected
+// deps so they are unit-testable; the default deps are the real browser glue.
+
+function sleep(ms) {
+  // Overridable in tests to avoid real timers.
+  if (typeof sleepImpl === 'function') return sleepImpl(ms);
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+const sanitize = (s) =>
+  (s || 'untitled').replace(/[^a-z0-9]+/gi, '_').replace(/^_+|_+$/g, '').slice(0, 60) || 'untitled';
+
+/** Compose the per-conversation ZIP filename (current-design naming). */
+function zipName(conv, data) {
+  const id = (conv.conversation_id || '').slice(0, 8);
+  const title = sanitize(conv.title || (data && data.metadata && data.metadata.title) || 'untitled');
+  return `${conv.site}-${title}-${id}.zip`;
+}
+
+// ---------------------------------------------------------------------------
+// Browser glue (default deps) — reuse the existing extract / zip / download path
+// ---------------------------------------------------------------------------
+
+/** Wait until a tab finishes loading. */
+function waitForTabComplete(tabId, timeoutMs = 45000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      chrome.tabs.onUpdated.removeListener(listener);
+      reject(new Error('tab load timeout'));
+    }, timeoutMs);
+    function listener(id, info) {
+      if (id === tabId && info.status === 'complete') {
+        clearTimeout(timer);
+        chrome.tabs.onUpdated.removeListener(listener);
+        resolve();
+      }
+    }
+    chrome.tabs.onUpdated.addListener(listener);
+  });
+}
+
+/** Send the existing extract message to the content script in a tab. */
+function sendExtract(tabId) {
+  return new Promise((resolve, reject) => {
+    chrome.tabs.sendMessage(tabId, { action: 'extract' }, (resp) => {
+      if (chrome.runtime.lastError) reject(new Error(chrome.runtime.lastError.message));
+      else resolve(resp);
+    });
+  });
+}
+
+/** Navigate the worker tab to a conversation and run the existing extractor. */
+async function navigateAndExtract(tabId, url) {
+  await chrome.tabs.update(tabId, { url });
+  await waitForTabComplete(tabId);
+  await sleep(1500); // let the SPA render + lazy content settle
+  const resp = await sendExtract(tabId);
+  if (!resp || !resp.success) throw new Error((resp && resp.error) || 'extraction failed');
+  return resp; // { success, data, images, warnings } — Clio's existing shape
+}
+
+/** Build the current-design ZIP (mirrors popup.js createZip). */
+async function buildZip(data, images) {
+  const zip = new JSZip();
+  zip.file('conversation.json', JSON.stringify(data, null, 2));
+  if (images && images.length) {
+    const folder = zip.folder('images');
+    for (const img of images) {
+      if (img && img.dataUrl && img.filename) {
+        folder.file(img.filename.replace('images/', ''), img.dataUrl.split(',')[1], { base64: true });
+      }
+    }
+  }
+  return zip.generateAsync({ type: 'blob', compression: 'DEFLATE' });
+}
+
+/** Save a ZIP blob via Chrome's download flow. */
+function downloadZip(blob, filename) {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(blob);
+    chrome.downloads.download({ url, filename, saveAs: false }, (downloadId) => {
+      setTimeout(() => URL.revokeObjectURL(url), 2000);
+      if (chrome.runtime.lastError) reject(new Error(chrome.runtime.lastError.message));
+      else resolve(downloadId);
+    });
+  });
+}
+
+const DEFAULT_DEPS = { navigateAndExtract, buildZip, downloadZip };
+
+// ---------------------------------------------------------------------------
+// The walk (testable core)
+// ---------------------------------------------------------------------------
+
+/** Process one conversation end-to-end; records success/failure in the ledger. */
+async function processOne(tabId, conv, deps = DEFAULT_DEPS) {
+  const keyObj = {
+    site: conv.site,
+    account_label: conv.account_label,
+    conversation_id: conv.conversation_id,
+  };
+  try {
+    const resp = await deps.navigateAndExtract(tabId, conv.url);
+    const blob = await deps.buildZip(resp.data, resp.images);
+    const filename = zipName(conv, resp.data);
+    await deps.downloadZip(blob, filename);
+    await markDownloaded(keyObj, { zip_name: filename });
+    return { ok: true, filename };
+  } catch (err) {
+    await markDownloadError(keyObj, (err && err.message) || String(err));
+    return { ok: false, error: (err && err.message) || String(err) };
+  }
+}
+
+/**
+ * Drain the ledger's queue, walking one conversation at a time.
+ * `control`: { tabId, paceMs, isPaused(), isCancelled(), onProgress(counts, last) }
+ */
+async function runBatch(control, deps = DEFAULT_DEPS) {
+  let done = 0;
+  let failed = 0;
+  for (;;) {
+    if (control.isCancelled && control.isCancelled()) break;
+    if (control.isPaused && control.isPaused()) { await sleep(400); continue; }
+
+    const queued = await dequeueNext();
+    if (!queued) break; // queue empty → finished
+
+    const conv = await getConversation(queued);
+    if (!conv) { failed += 1; continue; } // orphan queue row, skip
+
+    const result = await processOne(control.tabId, conv, deps);
+    if (result.ok) done += 1; else failed += 1;
+
+    if (control.onProgress) control.onProgress(await statusCounts(), { conv, result });
+    await sleep(control.paceMs || 800); // be polite between conversations
+  }
+  return { done, failed };
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    zipName, sanitize, buildZip, navigateAndExtract, waitForTabComplete, sendExtract,
+    downloadZip, processOne, runBatch, DEFAULT_DEPS,
+  };
+}

--- a/extensions/src/enumerate.js
+++ b/extensions/src/enumerate.js
@@ -1,0 +1,109 @@
+/* global document */
+// Clio 2.0 — conversation-list enumeration (#54).
+//
+// Walk the site's conversation list, scrolling until it stops growing (the list
+// lazy-loads more from the server as you scroll), and return every conversation
+// as { conversation_id, url, title }. Pure DOM — no API. The batch worker (#60)
+// turns this into the queue it drains.
+//
+// `collectConversations()` is a pure reader (unit-tested against real captured
+// DOM). `enumerateAll()` adds the scroll loop for the live page.
+
+function cleanTitle(t) {
+  t = (t || '').replace(/\s+/g, ' ').trim();
+  const h = t.length / 2; // sidebar rows sometimes duplicate the title (visible + tooltip)
+  if (t.length && t.length % 2 === 0 && t.slice(0, h) === t.slice(h)) t = t.slice(0, h);
+  return t.trim();
+}
+
+// Per-site list selectors. Each site renders conversation rows differently, and
+// Claude renders them BOTH as data-row-key buttons and as href anchors depending
+// on UI state — handle both.
+const SITE_LISTS = {
+  claude: {
+    itemSelector: '[data-row-key^="chat:"], a[href^="/chat/"]',
+    idFromItem(el) {
+      const key = el.getAttribute('data-row-key');
+      if (key && key.indexOf('chat:') === 0) return key.slice(5) || null;
+      const href = el.getAttribute('href') || '';
+      const m = href.match(/\/chat\/([0-9a-f-]+)/i);
+      return m ? m[1] : null;
+    },
+    urlFromId: (id) => `https://claude.ai/chat/${id}`,
+    titleFromItem: (el) => cleanTitle(el.textContent),
+  },
+  gemini: {
+    itemSelector: 'a[data-test-id="conversation"]',
+    idFromItem(el) {
+      const m = (el.getAttribute('href') || '').match(/\/app\/([0-9a-z]+)/i);
+      return m ? m[1] : null;
+    },
+    urlFromId: (id) => `https://gemini.google.com/app/${id}`,
+    titleFromItem(el) {
+      const t = el.querySelector('.conversation-title');
+      return cleanTitle((t || el).textContent);
+    },
+  },
+  // chatgpt: pending its real list DOM (#195)
+};
+
+/** Read every conversation currently rendered in `root` for `site` (deduped). */
+function collectConversations(root, site) {
+  const cfg = SITE_LISTS[site];
+  if (!cfg) throw new Error(`no list config for site: ${site}`);
+  const out = [];
+  const seen = new Set();
+  for (const el of root.querySelectorAll(cfg.itemSelector)) {
+    const id = cfg.idFromItem(el);
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    out.push({ site, conversation_id: id, url: cfg.urlFromId(id), title: cfg.titleFromItem(el) });
+  }
+  return out;
+}
+
+/** Find the scrollable ancestor that actually holds the conversation list. */
+function findListScroller(itemSelector) {
+  const item = document.querySelector(itemSelector);
+  if (!item) return null;
+  let el = item.parentElement;
+  while (el && el !== document.body) {
+    const style = getComputedStyle(el);
+    if ((style.overflowY === 'auto' || style.overflowY === 'scroll') && el.scrollHeight > el.clientHeight + 8) return el;
+    el = el.parentElement;
+  }
+  return null;
+}
+
+/**
+ * Scroll the list until it stops growing, accumulating every conversation.
+ * The list lazy-loads from the server as you reach the bottom, so keep going
+ * until the count is stable across several settle cycles.
+ */
+async function enumerateAll(site, opts = {}) {
+  const cfg = SITE_LISTS[site];
+  const { maxRounds = 400, settleMs = 700, stableNeeded = 6 } = opts;
+  const wait = opts.sleep || ((ms) => new Promise((r) => setTimeout(r, ms)));
+  const all = new Map();
+  const absorb = () => {
+    for (const c of collectConversations(document, site)) if (!all.has(c.conversation_id)) all.set(c.conversation_id, c);
+  };
+
+  let stable = 0;
+  absorb();
+  for (let i = 0; i < maxRounds && stable < stableNeeded; i++) {
+    const before = all.size;
+    const scroller = findListScroller(cfg.itemSelector);
+    if (scroller) scroller.scrollTop = scroller.scrollHeight;
+    const items = document.querySelectorAll(cfg.itemSelector);
+    if (items.length) items[items.length - 1].scrollIntoView({ block: 'end' });
+    await wait(settleMs); // let the server lazy-load the next page
+    absorb();
+    stable = all.size === before ? stable + 1 : 0;
+  }
+  return [...all.values()];
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { collectConversations, enumerateAll, findListScroller, cleanTitle, SITE_LISTS };
+}

--- a/extensions/src/popup.html
+++ b/extensions/src/popup.html
@@ -186,6 +186,8 @@
   </div>
 
   <button id="extractBtn">Extract Conversation</button>
+  <button id="downloadAllBtn" style="margin-top: 8px; background: #eef2f7; color: #223; border: 1px solid #cdd7e3;">Download All Conversations</button>
+  <div id="downloadAllNote" style="font-size: 11px; color: #888; margin-top: 6px; text-align: center;">Walks every conversation on this site and saves one ZIP each.</div>
 
   <div id="progress" class="progress">
     <div class="progress-bar">

--- a/extensions/src/popup.js
+++ b/extensions/src/popup.js
@@ -464,6 +464,22 @@ if (extractBtn) {
   });
 }
 
+// "Download All Conversations" opens the batch-download page for the current site.
+const downloadAllBtn = document.getElementById('downloadAllBtn');
+if (downloadAllBtn) {
+  downloadAllBtn.addEventListener('click', () => {
+    chrome.tabs.query({ active: true, currentWindow: true }, ([tab]) => {
+      if (!tab || !tab.url || !isSupportedSite(tab.url)) {
+        setStatus('Open a Gemini, Claude, or ChatGPT tab first, then Download All.', 'warning');
+        return;
+      }
+      const site = getSitePrefix(tab.url);
+      chrome.tabs.create({ url: chrome.runtime.getURL(`src/archive.html?site=${encodeURIComponent(site)}`) });
+      window.close();
+    });
+  });
+}
+
 // ============================================================================
 // Exports for Testing
 // ============================================================================

--- a/tests/archive.test.js
+++ b/tests/archive.test.js
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment node
+ */
+// Batch worker tests (#60) — the walk loop over the real ledger, with the
+// browser glue (navigate/extract/zip/download) injected as mocks.
+require('fake-indexeddb/auto');
+const { IDBFactory } = require('fake-indexeddb');
+const db = require('../extensions/src/storage/db.js');
+
+// archive.js references the db API and sleep as bare globals (loaded as sibling
+// <script>s in the extension). Expose them for the node test.
+Object.assign(global, {
+  getConversation: db.getConversation,
+  markDownloaded: db.markDownloaded,
+  markDownloadError: db.markDownloadError,
+  dequeueNext: db.dequeueNext,
+  statusCounts: db.statusCounts,
+  sleepImpl: () => Promise.resolve(), // no real delays in tests
+});
+const archive = require('../extensions/src/archive.js');
+
+const C1 = { site: 'claude', account_label: 'personal', conversation_id: 'aaa', title: 'One', url: 'https://claude.ai/chat/aaa' };
+const C2 = { site: 'claude', account_label: 'personal', conversation_id: 'bbb', title: 'Two', url: 'https://claude.ai/chat/bbb' };
+
+function okDeps() {
+  return {
+    navigateAndExtract: jest.fn(async () => ({ success: true, data: { metadata: { title: 'T' }, messages: [] }, images: [] })),
+    buildZip: jest.fn(async () => 'BLOB'),
+    downloadZip: jest.fn(async () => 7),
+  };
+}
+
+beforeEach(async () => {
+  globalThis.indexedDB = new IDBFactory();
+  db._resetDbCache();
+  await db.upsertConversation(C1);
+  await db.upsertConversation(C2);
+  await db.enqueueExtraction(C1);
+  await db.enqueueExtraction(C2);
+});
+
+describe('zipName / sanitize', () => {
+  test('composes a current-design filename', () => {
+    expect(archive.zipName(C1, { metadata: { title: 'One' } })).toBe('claude-One-aaa.zip');
+  });
+  test('sanitizes unsafe title chars', () => {
+    expect(archive.sanitize('Can\'t Stop: the math!')).toBe('Can_t_Stop_the_math');
+  });
+});
+
+describe('processOne', () => {
+  test('success path downloads and marks the ledger done', async () => {
+    const deps = okDeps();
+    const r = await archive.processOne(1, C1, deps);
+    expect(r).toEqual({ ok: true, filename: 'claude-One-aaa.zip' });
+    expect(deps.navigateAndExtract).toHaveBeenCalledWith(1, C1.url);
+    expect(deps.downloadZip).toHaveBeenCalledWith('BLOB', 'claude-One-aaa.zip');
+    const conv = await db.getConversation(C1);
+    expect(conv.download_status).toBe('done');
+    expect(conv.zip_name).toBe('claude-One-aaa.zip');
+  });
+
+  test('failure path records an error in the ledger (fail-open, keeps walking)', async () => {
+    const deps = okDeps();
+    deps.navigateAndExtract = jest.fn(async () => { throw new Error('render timeout'); });
+    const r = await archive.processOne(1, C1, deps);
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe('render timeout');
+    const conv = await db.getConversation(C1);
+    expect(conv.download_status).toBe('error');
+    expect(conv.download_error).toBe('render timeout');
+  });
+});
+
+describe('runBatch', () => {
+  test('drains the queue, marks all done, reports progress', async () => {
+    const deps = okDeps();
+    const onProgress = jest.fn();
+    const res = await archive.runBatch(
+      { tabId: 1, paceMs: 0, isPaused: () => false, isCancelled: () => false, onProgress }, deps);
+    expect(res).toEqual({ done: 2, failed: 0 });
+    expect(deps.navigateAndExtract).toHaveBeenCalledTimes(2);
+    expect(await db.statusCounts()).toMatchObject({ total: 2, done: 2, pending: 0 });
+    expect(onProgress).toHaveBeenCalledTimes(2);
+  });
+
+  test('cancel stops the walk immediately', async () => {
+    const deps = okDeps();
+    const res = await archive.runBatch(
+      { tabId: 1, paceMs: 0, isPaused: () => false, isCancelled: () => true }, deps);
+    expect(res).toEqual({ done: 0, failed: 0 });
+    expect(deps.navigateAndExtract).not.toHaveBeenCalled();
+  });
+
+  test('resume-safe: a second run only processes what is still pending', async () => {
+    const deps = okDeps();
+    await archive.runBatch({ tabId: 1, paceMs: 0, isPaused: () => false, isCancelled: () => false }, deps);
+    // Re-enqueue is idempotent for done rows; a fresh run should find nothing.
+    await db.enqueueExtraction(C1);
+    await db.enqueueExtraction(C2);
+    const deps2 = okDeps();
+    const res = await archive.runBatch({ tabId: 1, paceMs: 0, isPaused: () => false, isCancelled: () => false }, deps2);
+    expect(res).toEqual({ done: 0, failed: 0 });
+    expect(deps2.navigateAndExtract).not.toHaveBeenCalled();
+  });
+});

--- a/tests/archive.test.js
+++ b/tests/archive.test.js
@@ -11,6 +11,8 @@ const db = require('../extensions/src/storage/db.js');
 // <script>s in the extension). Expose them for the node test.
 Object.assign(global, {
   getConversation: db.getConversation,
+  upsertConversation: db.upsertConversation,
+  enqueueExtraction: db.enqueueExtraction,
   markDownloaded: db.markDownloaded,
   markDownloadError: db.markDownloadError,
   dequeueNext: db.dequeueNext,
@@ -53,7 +55,7 @@ describe('processOne', () => {
     const deps = okDeps();
     const r = await archive.processOne(1, C1, deps);
     expect(r).toEqual({ ok: true, filename: 'claude-One-aaa.zip' });
-    expect(deps.navigateAndExtract).toHaveBeenCalledWith(1, C1.url);
+    expect(deps.navigateAndExtract).toHaveBeenCalledWith(1, C1.url, 'claude');
     expect(deps.downloadZip).toHaveBeenCalledWith('BLOB', 'claude-One-aaa.zip');
     const conv = await db.getConversation(C1);
     expect(conv.download_status).toBe('done');
@@ -69,6 +71,25 @@ describe('processOne', () => {
     const conv = await db.getConversation(C1);
     expect(conv.download_status).toBe('error');
     expect(conv.download_error).toBe('render timeout');
+  });
+});
+
+describe('seedQueue', () => {
+  test('upserts conversations and enqueues them, then the worker drains them', async () => {
+    // fresh DB with nothing seeded (override the beforeEach seeding)
+    globalThis.indexedDB = new (require('fake-indexeddb').IDBFactory)();
+    db._resetDbCache();
+    const convs = [
+      { conversation_id: 'x1', url: 'https://claude.ai/chat/x1', title: 'X1' },
+      { conversation_id: 'x2', url: 'https://claude.ai/chat/x2', title: 'X2' },
+    ];
+    const res = await archive.seedQueue(convs, 'claude', 'personal');
+    expect(res).toEqual({ enumerated: 2, queued: 2 });
+    expect(await db.statusCounts()).toMatchObject({ total: 2, pending: 2 });
+
+    const walk = await archive.runBatch(
+      { tabId: 1, paceMs: 0, isPaused: () => false, isCancelled: () => false }, okDeps());
+    expect(walk).toEqual({ done: 2, failed: 0 });
   });
 });
 

--- a/tests/enumerate.test.js
+++ b/tests/enumerate.test.js
@@ -1,0 +1,49 @@
+// Enumeration reader tests (#54) — against REAL captured sidebar DOM, not
+// hand-crafted fixtures (per the DOM-first rule).
+const fs = require('fs');
+const path = require('path');
+const { collectConversations, cleanTitle } = require('../extensions/src/enumerate.js');
+
+function loadDoc(name) {
+  const html = fs.readFileSync(path.join(__dirname, 'fixtures', name), 'utf8');
+  return new DOMParser().parseFromString(html, 'text/html');
+}
+
+describe('collectConversations — Claude (real captured DOM)', () => {
+  let rows;
+  beforeAll(() => { rows = collectConversations(loadDoc('sidebar-claude.html'), 'claude'); });
+
+  test('finds all 32 conversations', () => {
+    expect(rows.length).toBe(32);
+  });
+  test('every row has a claude /chat/ URL and an id', () => {
+    expect(rows.every((r) => /^https:\/\/claude\.ai\/chat\/[0-9a-f-]+$/.test(r.url))).toBe(true);
+    expect(rows.every((r) => r.conversation_id)).toBe(true);
+  });
+  test('ids are unique', () => {
+    expect(new Set(rows.map((r) => r.conversation_id)).size).toBe(rows.length);
+  });
+  test('rows carry the site tag and a title', () => {
+    expect(rows.every((r) => r.site === 'claude')).toBe(true);
+    expect(rows.filter((r) => !r.title)).toEqual([]);
+  });
+});
+
+describe('collectConversations — Gemini (real captured DOM)', () => {
+  let rows;
+  beforeAll(() => { rows = collectConversations(loadDoc('sidebar-gemini.html'), 'gemini'); });
+
+  test('finds all 53 conversations with parseable ids', () => {
+    expect(rows.length).toBe(53);
+    expect(rows.every((r) => r.conversation_id && r.url.startsWith('https://gemini.google.com/app/'))).toBe(true);
+  });
+});
+
+describe('cleanTitle', () => {
+  test('collapses whitespace', () => {
+    expect(cleanTitle('  a\n  b  ')).toBe('a b');
+  });
+  test('de-duplicates a doubled title (visible + tooltip)', () => {
+    expect(cleanTitle('API usage informationAPI usage information')).toBe('API usage information');
+  });
+});


### PR DESCRIPTION
## What

Adds the end-to-end **Download All Conversations** walk to the existing Clio extension — no API, it reuses the DOM extractor so it captures rendered artifacts the site API cannot.

- **Enumerate (#54)** — `enumerate.js`: `collectConversations()` reads every conversation row from the live DOM (per-site, deduped); `enumerateAll()` scrolls the list until it stops growing (the list lazy-loads from the server as you reach the bottom). Unit-tested against real captured DOM: 32 Claude + 53 Gemini.
- **Worker (#60)** — `archive.js`: `runBatch()` drains the ledger queue; per conversation it navigates a worker tab, runs the existing `content.js` extractor, builds the current-design ZIP (`createZip`), downloads it, and records it in the ledger. Re-injects the content script if a navigation dropped it. Fail-open per conversation; resume-safe.
- **Progress UI (#63)** — `archive.html` + `archive-page.js`: a persistent page that opens a background worker tab, enumerates it via `chrome.scripting`, seeds the queue, runs the worker, and shows live progress with pause / resume / cancel. Plus a "Download All Conversations" button in the popup.
- **manifest**: version 1.4.1 → 1.5.0. No new permissions (existing `scripting` + host permissions cover driving the worker tab).

Builds on the ledger DB (already on main). The batch worker reuses the existing extractor unmodified.

## Tests

`fake-indexeddb` + jsdom. Worker + seedQueue (8), enumeration against real captured DOM (17), storage (10). Full suite: **319 passing**.

## Verification

Load unpacked and click Download All on claude.ai; browser-side timing/enumeration tuning to follow as a fast-follow.

Closes #54
Closes #60
Closes #63
