### PR TITLE
feat(archive): self-instrumentation run report (Closes #201)

### DIFF
--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Clio",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Extract full Gemini, Claude, and ChatGPT conversations to JSON with images",
   "permissions": [
     "activeTab",

--- a/extensions/src/archive-page.js
+++ b/extensions/src/archive-page.js
@@ -16,6 +16,24 @@ const SITE_BASE = {
 }[SITE] || 'https://claude.ai/';
 
 const control = { paused: false, cancelled: false };
+
+// Self-instrumentation: a machine-readable record of the whole run, downloaded at
+// the end so the result can be verified against ground truth without any relay.
+const runReport = {
+  site: SITE, account: ACCOUNT, startedAt: null, finishedAt: null,
+  enumerated: null, results: [], summary: null,
+};
+
+function downloadReport() {
+  const blob = new Blob([JSON.stringify(runReport, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  chrome.downloads.download(
+    { url, filename: `clio-archive/clio-run-report-${SITE}-${ts}.json`, saveAs: false },
+    () => setTimeout(() => URL.revokeObjectURL(url), 2000),
+  );
+}
+
 const $ = (id) => document.getElementById(id);
 const setPhase = (t) => { $('phase').textContent = t; };
 
@@ -97,9 +115,16 @@ async function main() {
 
   setPhase('Enumerating conversations (scrolling the list)…');
   const convs = await enumerateInTab(tabId);
+  runReport.startedAt = new Date().toISOString();
+  runReport.enumerated = {
+    count: convs.length,
+    conversations: convs.map((c) => ({ id: c.conversation_id, title: c.title, url: c.url })),
+  };
   log(`Enumerated ${convs.length} conversations.`);
   if (!convs.length) {
     setPhase('No conversations found — make sure you are logged in and the sidebar is visible, then reload.');
+    runReport.summary = { done: 0, failed: 0, note: 'enumeration found nothing' };
+    downloadReport();
     return;
   }
 
@@ -112,14 +137,31 @@ async function main() {
     paceMs: 800,
     isPaused: () => control.paused,
     isCancelled: () => control.cancelled,
-    onProgress: (counts, last) => render(counts, last),
+    onProgress: (counts, last) => {
+      render(counts, last);
+      if (last && last.conv) {
+        runReport.results.push({
+          id: last.conv.conversation_id,
+          title: last.conv.title,
+          status: last.result.ok ? 'done' : 'error',
+          filename: last.result.filename || null,
+          messageCount: last.result.messageCount,
+          imageCount: last.result.imageCount,
+          textLength: last.result.textLength,
+          error: last.result.error || null,
+        });
+      }
+    },
   });
 
   render(await statusCounts({ site: SITE, account_label: ACCOUNT }));
+  runReport.finishedAt = new Date().toISOString();
+  runReport.summary = { done: res.done, failed: res.failed, cancelled: control.cancelled };
+  downloadReport();
   setPhase(control.cancelled
-    ? `Cancelled — ${res.done} downloaded, ${res.failed} failed.`
-    : `Done — ${res.done} downloaded, ${res.failed} failed.`);
-  log(`FINISHED: ${res.done} downloaded, ${res.failed} failed.`);
+    ? `Cancelled — ${res.done} downloaded, ${res.failed} failed. Run report saved to clio-archive/.`
+    : `Done — ${res.done} downloaded, ${res.failed} failed. Run report saved to clio-archive/.`);
+  log(`FINISHED: ${res.done} downloaded, ${res.failed} failed. Report + ZIPs in Downloads/clio-archive/.`);
   $('pauseBtn').disabled = true;
 }
 

--- a/extensions/src/archive.js
+++ b/extensions/src/archive.js
@@ -20,11 +20,23 @@ function sleep(ms) {
 const sanitize = (s) =>
   (s || 'untitled').replace(/[^a-z0-9]+/gi, '_').replace(/^_+|_+$/g, '').slice(0, 60) || 'untitled';
 
-/** Compose the per-conversation ZIP filename (current-design naming). */
+/** Compose the per-conversation ZIP path (organized under a clio-archive/ folder). */
 function zipName(conv, data) {
   const id = (conv.conversation_id || '').slice(0, 8);
   const title = sanitize(conv.title || (data && data.metadata && data.metadata.title) || 'untitled');
-  return `${conv.site}-${title}-${id}.zip`;
+  return `clio-archive/${conv.site}-${title}-${id}.zip`;
+}
+
+/** What the extractor saw for one conversation — recorded in the run report. */
+function extractionDiagnostics(resp) {
+  const data = (resp && resp.data) || {};
+  const meta = data.metadata || {};
+  const messages = data.messages || [];
+  return {
+    messageCount: meta.messageCount != null ? meta.messageCount : messages.length,
+    imageCount: meta.imageCount != null ? meta.imageCount : ((resp && resp.images) || []).length,
+    textLength: JSON.stringify(messages).length,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -133,7 +145,7 @@ async function processOne(tabId, conv, deps = DEFAULT_DEPS) {
     const filename = zipName(conv, resp.data);
     await deps.downloadZip(blob, filename);
     await markDownloaded(keyObj, { zip_name: filename });
-    return { ok: true, filename };
+    return { ok: true, filename, ...extractionDiagnostics(resp) };
   } catch (err) {
     await markDownloadError(keyObj, (err && err.message) || String(err));
     return { ok: false, error: (err && err.message) || String(err) };
@@ -180,6 +192,7 @@ async function seedQueue(convs, site, account_label) {
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
     zipName, sanitize, buildZip, navigateAndExtract, waitForTabComplete, sendExtract,
-    downloadZip, processOne, runBatch, seedQueue, scriptsForSite, CONTENT_SCRIPTS, DEFAULT_DEPS,
+    downloadZip, processOne, runBatch, seedQueue, scriptsForSite, CONTENT_SCRIPTS,
+    extractionDiagnostics, DEFAULT_DEPS,
   };
 }

--- a/tests/archive.test.js
+++ b/tests/archive.test.js
@@ -42,8 +42,8 @@ beforeEach(async () => {
 });
 
 describe('zipName / sanitize', () => {
-  test('composes a current-design filename', () => {
-    expect(archive.zipName(C1, { metadata: { title: 'One' } })).toBe('claude-One-aaa.zip');
+  test('composes a current-design filename under clio-archive/', () => {
+    expect(archive.zipName(C1, { metadata: { title: 'One' } })).toBe('clio-archive/claude-One-aaa.zip');
   });
   test('sanitizes unsafe title chars', () => {
     expect(archive.sanitize('Can\'t Stop: the math!')).toBe('Can_t_Stop_the_math');
@@ -54,12 +54,13 @@ describe('processOne', () => {
   test('success path downloads and marks the ledger done', async () => {
     const deps = okDeps();
     const r = await archive.processOne(1, C1, deps);
-    expect(r).toEqual({ ok: true, filename: 'claude-One-aaa.zip' });
+    expect(r).toMatchObject({ ok: true, filename: 'clio-archive/claude-One-aaa.zip' });
+    expect(r).toHaveProperty('messageCount'); // diagnostics recorded for the run report
     expect(deps.navigateAndExtract).toHaveBeenCalledWith(1, C1.url, 'claude');
-    expect(deps.downloadZip).toHaveBeenCalledWith('BLOB', 'claude-One-aaa.zip');
+    expect(deps.downloadZip).toHaveBeenCalledWith('BLOB', 'clio-archive/claude-One-aaa.zip');
     const conv = await db.getConversation(C1);
     expect(conv.download_status).toBe('done');
-    expect(conv.zip_name).toBe('claude-One-aaa.zip');
+    expect(conv.zip_name).toBe('clio-archive/claude-One-aaa.zip');
   });
 
   test('failure path records an error in the ledger (fail-open, keeps walking)', async () => {


### PR DESCRIPTION
Adds a downloaded run report so a Download-All run can be verified against ground truth without relaying the on-screen log. Records the enumerated conversation list and each conversation's outcome (status, zip, message/image counts, text size, errors) to `clio-archive/clio-run-report-<site>-<ts>.json`; ZIPs also organized under `clio-archive/`. Manifest 1.5.0 -> 1.5.1. 319 tests pass.

Closes #201