### PR TITLE
fix(archive): full-list enumeration + extraction render-timing + Pause button

### DIFF
--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Clio",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Extract full Gemini, Claude, and ChatGPT conversations to JSON with images",
   "permissions": [
     "activeTab",

--- a/extensions/src/archive-page.js
+++ b/extensions/src/archive-page.js
@@ -89,11 +89,11 @@ async function enumerateInTab(tabId) {
   }).catch(() => {});
   await new Promise((r) => setTimeout(r, 1200));
 
-  // Inject the enumerator and run scroll-until-stable inside the tab.
+  // Inject the enumerator and get the COMPLETE conversation list inside the tab.
   await chrome.scripting.executeScript({ target: { tabId }, files: ['src/enumerate.js'] });
   const [{ result }] = await chrome.scripting.executeScript({
     target: { tabId },
-    func: (site) => window.enumerateAll(site),
+    func: (site) => window.enumerateFull(site),
     args: [SITE],
   });
   return result || [];
@@ -113,7 +113,7 @@ async function main() {
   setPhase('Opening a worker tab…');
   const tabId = await ensureWorkerTab();
 
-  setPhase('Enumerating conversations (scrolling the list)…');
+  setPhase('Getting your full conversation list…');
   const convs = await enumerateInTab(tabId);
   runReport.startedAt = new Date().toISOString();
   runReport.enumerated = {

--- a/extensions/src/archive.html
+++ b/extensions/src/archive.html
@@ -21,7 +21,7 @@
     .controls { display: flex; gap: 10px; margin-top: 16px; }
     button {
       font-size: 14px; padding: 8px 18px; border-radius: 8px; border: 1px solid #ccc;
-      background: #fff; cursor: pointer;
+      background: #fff; color: #1a1a1a; cursor: pointer;
     }
     button:hover { background: #f0f0f0; }
     button#cancelBtn { border-color: #e0b4b4; color: #a33; }

--- a/extensions/src/archive.js
+++ b/extensions/src/archive.js
@@ -79,24 +79,41 @@ const CONTENT_SCRIPTS = {
 };
 const scriptsForSite = (site) => CONTENT_SCRIPTS[site] || CONTENT_SCRIPTS.claude;
 
-/** Navigate the worker tab to a conversation and run the existing extractor. */
+/**
+ * Navigate the worker tab to a conversation and run the existing extractor.
+ * Waits for the conversation's messages to actually render (SPA load is not
+ * instant) by retrying with growing delays. Two failure classes are handled:
+ *  - "receiving end / Could not establish" → content script dropped by the
+ *    navigation; re-inject and retry.
+ *  - "Missing selectors: messages" → messages haven't rendered yet; wait longer.
+ *    If it persists across all attempts the conversation is (likely) empty.
+ */
 async function navigateAndExtract(tabId, url, site) {
   await chrome.tabs.update(tabId, { url });
   await waitForTabComplete(tabId);
-  await sleep(1500); // let the SPA render + lazy content settle
-  try {
-    const resp = await sendExtract(tabId);
-    if (!resp || !resp.success) throw new Error((resp && resp.error) || 'extraction failed');
-    return resp; // { success, data, images, warnings } — Clio's existing shape
-  } catch (err) {
-    // The content script may not be present after a fresh navigation — inject it and retry once.
-    if (!/receiving end|Could not establish/i.test(err.message || '')) throw err;
-    await chrome.scripting.executeScript({ target: { tabId }, files: scriptsForSite(site) });
-    await sleep(800);
-    const resp = await sendExtract(tabId);
-    if (!resp || !resp.success) throw new Error((resp && resp.error) || 'extraction failed after reinject');
-    return resp;
+
+  let lastError = 'extraction failed';
+  const MAX_ATTEMPTS = 5;
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    await sleep(Math.min(1500 + attempt * 1500, 6000)); // 1.5s, 3s, 4.5s, 6s, 6s
+    let resp;
+    try {
+      resp = await sendExtract(tabId);
+    } catch (err) {
+      if (/receiving end|Could not establish/i.test(err.message || '')) {
+        // Content script isn't present after the navigation — inject and retry.
+        await chrome.scripting.executeScript({ target: { tabId }, files: scriptsForSite(site) });
+        continue;
+      }
+      throw err;
+    }
+    if (resp && resp.success) return resp; // { success, data, images, warnings }
+    lastError = (resp && resp.error) || 'extraction failed';
+    // A non-timing extractor error is real — surface it immediately.
+    if (!/missing selectors: messages/i.test(lastError)) throw new Error(lastError);
+    // else: messages not rendered yet — loop and wait longer.
   }
+  throw new Error(lastError); // exhausted retries: slow render or an empty conversation
 }
 
 /** Build the current-design ZIP (mirrors popup.js createZip). */

--- a/extensions/src/enumerate.js
+++ b/extensions/src/enumerate.js
@@ -104,6 +104,51 @@ async function enumerateAll(site, opts = {}) {
   return [...all.values()];
 }
 
+// The sidebar caps at ~recent conversations, so it cannot enumerate a large
+// archive by scrolling. For the COMPLETE list we read the account's own
+// conversation index (the same data the web app uses to render the list). This
+// returns every conversation id/title — each conversation's CONTENT is still
+// opened and DOM-extracted by the worker, so artifacts are not lost here.
+async function fetchConversationListClaude() {
+  const j = async (u) => {
+    const r = await fetch(u, { headers: { accept: 'application/json' }, credentials: 'include' });
+    return r.ok ? r.json() : null;
+  };
+  const orgs = await j('/api/organizations');
+  const org = (Array.isArray(orgs) ? orgs : []).find((o) => (o.capabilities || []).includes('chat')) || (orgs || [])[0];
+  if (!org) return [];
+  const out = [];
+  const seen = new Set();
+  for (let offset = 0; offset < 6000; offset += 100) {
+    const batch = await j(`/api/organizations/${org.uuid}/chat_conversations?limit=100&offset=${offset}`);
+    if (!Array.isArray(batch) || !batch.length) break;
+    let added = 0;
+    for (const c of batch) {
+      if (c.uuid && !seen.has(c.uuid)) {
+        seen.add(c.uuid);
+        out.push({ site: 'claude', conversation_id: c.uuid, url: `https://claude.ai/chat/${c.uuid}`, title: c.name || '' });
+        added += 1;
+      }
+    }
+    if (!added || batch.length < 100) break;
+  }
+  return out;
+}
+
+/** Full conversation list for a site: complete index where available, else scroll. */
+async function enumerateFull(site) {
+  if (site === 'claude') {
+    try {
+      const list = await fetchConversationListClaude();
+      if (list.length) return list;
+    } catch (e) { /* fall through to scroll */ }
+  }
+  return enumerateAll(site); // gemini / chatgpt (or claude fallback): scroll the visible list
+}
+
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { collectConversations, enumerateAll, findListScroller, cleanTitle, SITE_LISTS };
+  module.exports = {
+    collectConversations, enumerateAll, enumerateFull, fetchConversationListClaude,
+    findListScroller, cleanTitle, SITE_LISTS,
+  };
 }


### PR DESCRIPTION
First browser run of the Download-All walk (#200) surfaced three bugs, diagnosed from the extension's own run report (23 done / 10 failed / enumerated 33):

- **Enumeration** returned ~33 (Claude's sidebar caps at recents), not the full 223. Now reads the complete conversation index; every conversation is walked, content still DOM-extracted per conversation.
- **10 'Missing selectors: messages' failures** were a fixed 1.5s wait firing before the conversation rendered — now retries with growing delays until messages appear.
- **Blank Pause button** — button CSS set background but no text color. Fixed.

Per-conversation streaming downloads retained (bounded memory). Manifest 1.5.1 -> 1.5.2. 319 tests pass.

No-Issue: same-session fixes from the first browser test of the #200 walk