### PR TITLE
fix(extraction): CSS bleed, blank turns, doubled titles, history loading + verify harness (Closes #206, #208, #209)

### DIFF
--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Clio",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Extract full Gemini, Claude, and ChatGPT conversations to JSON with images",
   "permissions": [
     "activeTab",

--- a/extensions/src/archive-page.js
+++ b/extensions/src/archive-page.js
@@ -70,7 +70,10 @@ function tabComplete(tabId) {
 }
 
 async function ensureWorkerTab() {
-  const tab = await chrome.tabs.create({ url: SITE_BASE, active: false }); // background; user watches this page
+  // The worker tab must be ACTIVE: a background tab doesn't trigger Claude's
+  // lazy-load of older messages, so scrollToLoadAllMessages only sees the last
+  // ~10 turns and long conversations get truncated (#204). Keep it foreground.
+  const tab = await chrome.tabs.create({ url: SITE_BASE, active: true });
   await tabComplete(tab.id);
   await new Promise((r) => setTimeout(r, 3000)); // let the app hydrate
   return tab.id;

--- a/extensions/src/content.js
+++ b/extensions/src/content.js
@@ -562,6 +562,11 @@ function extractTextContent(element) {
   // Clone to avoid modifying the DOM
   const clone = element.cloneNode(true);
 
+  // Strip non-content nodes that otherwise bleed into textContent. Claude's
+  // animated web-search "Research complete" widget injects <style> keyframes
+  // inside the message subtree, which would land in the extracted text (#206).
+  clone.querySelectorAll('style, script').forEach(el => el.remove());
+
   // Process code blocks - preserve with markdown formatting
   const codeBlocks = clone.querySelectorAll(SELECTORS.codeBlock);
   codeBlocks.forEach(code => {
@@ -1225,7 +1230,16 @@ async function extractConversation() {
 
     // Phase 4: Extract turns
     showProgress('Extracting conversation...');
-    const turns = await extractTurns();
+    const rawTurns = await extractTurns();
+    // Drop blank turns — thinking-only / artifact-only shells that produce an
+    // empty-content message (#208); re-index so positions stay contiguous.
+    const turns = rawTurns
+      .filter(t =>
+        (t.content && t.content.trim()) ||
+        (t.thinking && String(t.thinking).trim()) ||
+        (t.attachments && t.attachments.length) ||
+        (t.toolUse && t.toolUse.length))
+      .map((t, i) => ({ ...t, index: i }));
 
     // Phase 5: Extract images (Fail Open)
     const { images, errors } = await extractImages(turns);

--- a/extensions/src/enumerate.js
+++ b/extensions/src/enumerate.js
@@ -11,8 +11,11 @@
 
 function cleanTitle(t) {
   t = (t || '').replace(/\s+/g, ' ').trim();
-  const h = t.length / 2; // sidebar rows sometimes duplicate the title (visible + tooltip)
+  // Some conversation names come back doubled — either exact ("XX") or
+  // whitespace-separated ("X X"). Collapse both (#209).
+  const h = t.length / 2;
   if (t.length && t.length % 2 === 0 && t.slice(0, h) === t.slice(h)) t = t.slice(0, h);
+  t = t.replace(/^(.+?)\s+\1$/, '$1');
   return t.trim();
 }
 
@@ -126,7 +129,7 @@ async function fetchConversationListClaude() {
     for (const c of batch) {
       if (c.uuid && !seen.has(c.uuid)) {
         seen.add(c.uuid);
-        out.push({ site: 'claude', conversation_id: c.uuid, url: `https://claude.ai/chat/${c.uuid}`, title: c.name || '' });
+        out.push({ site: 'claude', conversation_id: c.uuid, url: `https://claude.ai/chat/${c.uuid}`, title: cleanTitle(c.name || '') });
         added += 1;
       }
     }

--- a/tests/enumerate.test.js
+++ b/tests/enumerate.test.js
@@ -46,4 +46,11 @@ describe('cleanTitle', () => {
   test('de-duplicates a doubled title (visible + tooltip)', () => {
     expect(cleanTitle('API usage informationAPI usage information')).toBe('API usage information');
   });
+  test('de-duplicates a space-separated doubled title (#209)', () => {
+    expect(cleanTitle('CLOSED: clustering of PES-LRP-SC5 CLOSED: clustering of PES-LRP-SC5'))
+      .toBe('CLOSED: clustering of PES-LRP-SC5');
+  });
+  test('leaves a normal title untouched', () => {
+    expect(cleanTitle('A perfectly normal title')).toBe('A perfectly normal title');
+  });
 });

--- a/tests/extraction-fixes.test.js
+++ b/tests/extraction-fixes.test.js
@@ -1,0 +1,30 @@
+// Regression tests for extraction anomalies found in the first browser run.
+// SELECTORS must exist before content.js is required (it reads the global).
+global.SELECTORS = { codeBlock: 'pre code', site: 'claude' };
+const { extractTextContent } = require('../extensions/src/content.js');
+
+describe('#206 — CSS/<style> must not bleed into extracted text', () => {
+  test('strips <style> (web-search widget keyframes) from the message subtree', () => {
+    const el = document.createElement('div');
+    el.innerHTML =
+      'The load factor is ~0.90.<style>@keyframes slideUpFadeOut { 0% { transform: translateY(0); opacity: 1; } }</style> Research complete.';
+    const out = extractTextContent(el);
+    expect(out).toContain('The load factor is ~0.90.');
+    expect(out).toContain('Research complete.');
+    expect(out).not.toMatch(/@keyframes|translateY|opacity/);
+  });
+
+  test('strips <script> too', () => {
+    const el = document.createElement('div');
+    el.innerHTML = 'Answer text<script>window.x=1</script>';
+    const out = extractTextContent(el);
+    expect(out).toContain('Answer text');
+    expect(out).not.toContain('window.x');
+  });
+
+  test('leaves real code blocks intact (only style/script removed)', () => {
+    const el = document.createElement('div');
+    el.innerHTML = 'Here:<pre><code>const a = 1;</code></pre>';
+    expect(extractTextContent(el)).toContain('const a = 1;');
+  });
+});

--- a/tools/verify_export.py
+++ b/tools/verify_export.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+Verify a Clio batch-download run against an independent oracle.
+
+Diffs each DOM-extracted conversation ZIP (what the extension produced) against
+the site's data-API export (a structurally-clean second source of truth), and
+reports per-conversation and corpus anomalies. This is the operational form of
+the "oracle diff" verification layer (docs/testing/extraction-verification-strategy.md).
+
+Usage:
+    python tools/verify_export.py <clio-archive-dir> <oracle-dir> [--json]
+
+    <clio-archive-dir>  folder of extension-produced ZIPs (e.g. Downloads/clio-archive)
+    <oracle-dir>        folder of API-export ZIPs        (e.g. data/claude-export/zips)
+
+Exit code is non-zero if any corpus invariant is violated.
+"""
+import argparse
+import json
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+CSS_LEAK = re.compile(r"@keyframes|<style\b")
+REPLACEMENT = "�"
+
+
+def load_zip_conversations(folder: Path) -> dict:
+    """id -> normalized conversation dict, from every ZIP holding a conversation.json."""
+    out = {}
+    for zpath in sorted(folder.glob("*.zip")):
+        try:
+            with zipfile.ZipFile(zpath) as zf:
+                if "conversation.json" not in zf.namelist():
+                    continue
+                data = json.loads(zf.read("conversation.json").decode("utf-8"))
+                images = [n for n in zf.namelist() if n.startswith("images/") and not n.endswith("/")]
+        except (zipfile.BadZipFile, json.JSONDecodeError, KeyError):
+            continue
+        meta = data.get("metadata", {})
+        cid = meta.get("conversationId")
+        if not cid:
+            continue
+        msgs = data.get("messages", [])
+        out[cid] = {
+            "id": cid,
+            "title": meta.get("title", ""),
+            "count": len(msgs),
+            "roles": [m.get("role") for m in msgs],
+            "texts": [(m.get("content") or m.get("text") or m.get("allText") or "") for m in msgs],
+            "image_files": len(images),
+        }
+    return out
+
+
+def analyze(dom: dict, oracle: dict) -> dict:
+    """Return per-conversation findings comparing DOM extraction against the oracle."""
+    full_text = "\n".join(dom["texts"])
+    o = oracle.get(dom["id"])
+    flags = []
+
+    # #204 — dropped turns vs oracle
+    if o is not None and dom["count"] < o["count"]:
+        flags.append(f"DROPPED-TURNS(dom {dom['count']} < api {o['count']})")
+
+    # #205 — first turn should be a user turn
+    if dom["roles"] and dom["roles"][0] != "user":
+        flags.append("NO-OPENING-USER")
+
+    # #208 — blank message
+    empties = sum(1 for t in dom["texts"] if not t.strip())
+    if empties:
+        flags.append(f"{empties}-EMPTY-MSG")
+
+    # #206 — CSS/style leaked into content
+    if CSS_LEAK.search(full_text):
+        flags.append("CSS-IN-CONTENT")
+
+    # #209 — doubled title ("X X")
+    t = (dom["title"] or "").strip()
+    if t and re.match(r"^(.{3,}?)\s+\1$", t):
+        flags.append("DOUBLED-TITLE")
+
+    # Unicode integrity
+    if REPLACEMENT in full_text:
+        flags.append("UNICODE-CORRUPTION")
+
+    return {"id": dom["id"], "title": dom["title"], "count": dom["count"],
+            "oracle_count": o["count"] if o else None, "flags": flags}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Verify a Clio export against the API oracle.")
+    ap.add_argument("archive_dir")
+    ap.add_argument("oracle_dir")
+    ap.add_argument("--json", action="store_true", help="emit JSON instead of a table")
+    args = ap.parse_args()
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # Windows console is cp1252
+    except AttributeError:
+        pass
+
+    dom = load_zip_conversations(Path(args.archive_dir))
+    oracle = load_zip_conversations(Path(args.oracle_dir))
+    if not dom:
+        print(f"No conversation ZIPs found in {args.archive_dir}", file=sys.stderr)
+        return 2
+
+    findings = [analyze(c, oracle) for c in dom.values()]
+    flagged = [f for f in findings if f["flags"]]
+
+    if args.json:
+        print(json.dumps({"total": len(findings), "flagged": flagged}, indent=2))
+    else:
+        print(f"Verifying {len(dom)} extracted conversations against {len(oracle)} oracle conversations\n")
+        for f in sorted(findings, key=lambda x: (not x["flags"], x["title"])):
+            mark = "  " if not f["flags"] else "!!"
+            oc = f"/{f['oracle_count']}" if f["oracle_count"] is not None else ""
+            print(f"  {mark}{str(f['count'])+oc:>7}msg  {', '.join(f['flags']) or 'ok':<40} {f['title'][:40]}")
+        # corpus summary
+        print(f"\n=== corpus ===")
+        print(f"  extracted: {len(dom)}   oracle: {len(oracle)}   in-oracle-not-extracted: {len(set(oracle)-set(dom))}")
+        from collections import Counter
+        tally = Counter(flag.split('(')[0] for f in flagged for flag in f["flags"])
+        for k, v in tally.most_common():
+            print(f"  {v:>3}  {k}")
+
+    # invariant gate: real content-loss classes fail the run
+    hard = [f for f in findings if any(x.startswith(("DROPPED-TURNS", "UNICODE-CORRUPTION", "CSS-IN-CONTENT")) for x in f["flags"])]
+    return 1 if hard else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Diagnosed with the new `tools/verify_export.py` oracle-diff harness (compares each extracted conversation against the API export).

- **#206** — extractTextContent strips `<style>`/`<script>` so web-search widget keyframes stop bleeding into message text.
- **#208** — blank turns dropped + re-indexed (also clears the false 'no opening user' they caused).
- **#209** — cleanTitle collapses space-separated doubled names; full-list titles run through it.
- **#204 (addressed, verify pending)** — the ~10-message cap was the *background* worker tab not triggering Claude's lazy-load of older turns; the worker tab is now active so history loads. `verify_export` will confirm dom-count == oracle-count on the next run — leaving #204 open until it does.

New `tools/verify_export.py`: oracle-diff gate. Manifest 1.5.2 -> 1.5.3. 324 tests pass. #205/#207 (deep-research shape) need real DOM and are deferred.

Closes #206
Closes #208
Closes #209