### PR TITLE
feat(archive): Start-over + per-run subfolders for clean re-runs

### DIFF
--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Clio",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Extract full Gemini, Claude, and ChatGPT conversations to JSON with images",
   "permissions": [
     "activeTab",

--- a/extensions/src/archive-page.js
+++ b/extensions/src/archive-page.js
@@ -15,6 +15,10 @@ const SITE_BASE = {
   chatgpt: 'https://chatgpt.com/',
 }[SITE] || 'https://claude.ai/';
 
+// Per-run subfolder so this run's files can't collide with an earlier run's.
+const RUN = 'run-' + new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+setRunTag(RUN);
+
 const control = { paused: false, cancelled: false };
 
 // Self-instrumentation: a machine-readable record of the whole run, downloaded at
@@ -27,9 +31,8 @@ const runReport = {
 function downloadReport() {
   const blob = new Blob([JSON.stringify(runReport, null, 2)], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
-  const ts = new Date().toISOString().replace(/[:.]/g, '-');
   chrome.downloads.download(
-    { url, filename: `clio-archive/clio-run-report-${SITE}-${ts}.json`, saveAs: false },
+    { url, filename: `clio-archive/${RUN}/clio-run-report-${SITE}.json`, saveAs: false },
     () => setTimeout(() => URL.revokeObjectURL(url), 2000),
   );
 }
@@ -103,13 +106,19 @@ async function enumerateInTab(tabId) {
 }
 
 async function main() {
-  $('site').textContent = `Site: ${SITE} · account: ${ACCOUNT}`;
+  $('site').textContent = `Site: ${SITE} · account: ${ACCOUNT} · saving to Downloads/clio-archive/${RUN}/`;
   $('pauseBtn').onclick = () => {
     control.paused = !control.paused;
     $('pauseBtn').textContent = control.paused ? 'Resume' : 'Pause';
     setPhase(control.paused ? 'Paused' : 'Walking & downloading…');
   };
   $('cancelBtn').onclick = () => { control.cancelled = true; setPhase('Cancelling…'); };
+  $('resetBtn').onclick = async () => {
+    if (!confirm('Clear saved progress and re-download EVERY conversation from scratch? Use this after an update so the fixes apply to all conversations.')) return;
+    control.cancelled = true;
+    await clearAll();
+    location.reload();
+  };
 
   await openDb();
 

--- a/extensions/src/archive.html
+++ b/extensions/src/archive.html
@@ -46,8 +46,9 @@
     <div class="controls">
       <button id="pauseBtn">Pause</button>
       <button id="cancelBtn">Cancel</button>
+      <button id="resetBtn">Start over</button>
     </div>
-    <div class="note">Keep this tab open until it finishes. It walks each conversation, extracts it with Clio's normal extractor, and downloads one ZIP per conversation. Already-downloaded conversations are skipped, so you can safely stop and resume.</div>
+    <div class="note">Keep this tab open until it finishes. It walks each conversation, runs Clio's normal extractor, and downloads one ZIP per conversation into <code>Downloads/clio-archive/</code>. Downloaded conversations are skipped, so you can pause and resume. <b>Start over</b> clears saved progress and re-downloads everything — use it after an update so fixes apply to all conversations.</div>
   </div>
 
   <div id="log"></div>

--- a/extensions/src/archive.js
+++ b/extensions/src/archive.js
@@ -20,11 +20,17 @@ function sleep(ms) {
 const sanitize = (s) =>
   (s || 'untitled').replace(/[^a-z0-9]+/gi, '_').replace(/^_+|_+$/g, '').slice(0, 60) || 'untitled';
 
-/** Compose the per-conversation ZIP path (organized under a clio-archive/ folder). */
+// A per-run tag so a fresh run lands in its own subfolder and can't collide with
+// files from an earlier (e.g. buggy) run.
+let RUN_TAG = '';
+const setRunTag = (t) => { RUN_TAG = t || ''; };
+const archiveDir = () => (RUN_TAG ? `clio-archive/${RUN_TAG}` : 'clio-archive');
+
+/** Compose the per-conversation ZIP path (organized under the run's folder). */
 function zipName(conv, data) {
   const id = (conv.conversation_id || '').slice(0, 8);
   const title = sanitize(conv.title || (data && data.metadata && data.metadata.title) || 'untitled');
-  return `clio-archive/${conv.site}-${title}-${id}.zip`;
+  return `${archiveDir()}/${conv.site}-${title}-${id}.zip`;
 }
 
 /** What the extractor saw for one conversation — recorded in the run report. */
@@ -210,6 +216,6 @@ if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
     zipName, sanitize, buildZip, navigateAndExtract, waitForTabComplete, sendExtract,
     downloadZip, processOne, runBatch, seedQueue, scriptsForSite, CONTENT_SCRIPTS,
-    extractionDiagnostics, DEFAULT_DEPS,
+    extractionDiagnostics, setRunTag, archiveDir, DEFAULT_DEPS,
   };
 }

--- a/extensions/src/storage/db.js
+++ b/extensions/src/storage/db.js
@@ -226,6 +226,18 @@ const recordRun = (run) =>
 const getSetting = async (key) => (await _get('settings', key))?.value;
 const setSetting = (key, value) => _put('settings', { key, value });
 
+/** Wipe all data (fresh start / "re-download everything"). */
+async function clearAll() {
+  const db = await openDb();
+  const names = Array.from(db.objectStoreNames);
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(names, 'readwrite');
+    for (const name of names) transaction.objectStore(name).clear();
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error);
+  });
+}
+
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
     DB_NAME, DB_VERSION, STORES,
@@ -234,6 +246,6 @@ if (typeof module !== 'undefined' && module.exports) {
     upsertConversation, getConversation, listConversations,
     markDownloaded, markDownloadError, statusCounts,
     enqueueExtraction, dequeueNext,
-    recordRun, getSetting, setSetting,
+    recordRun, getSetting, setSetting, clearAll,
   };
 }

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -102,4 +102,14 @@ describe('harvest runs + settings', () => {
     expect(await db.getSetting('rate_ms')).toBe(400);
     expect(await db.getSetting('missing')).toBeUndefined();
   });
+
+  test('clearAll wipes every store (Start over)', async () => {
+    await db.upsertConversation({ ...K, title: 'A' });
+    await db.enqueueExtraction(K);
+    await db.setSetting('x', 1);
+    await db.clearAll();
+    expect(await db.listConversations()).toEqual([]);
+    expect(await db.dequeueNext()).toBeNull();
+    expect(await db.getSetting('x')).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Enables a clean full re-run after the extraction fixes. `db.clearAll()` + a 'Start over' button clear saved progress and re-download everything; each run saves to `Downloads/clio-archive/run-<timestamp>/` so a fresh run never collides with an earlier run's files. Manifest 1.5.3 -> 1.5.4. 325 tests pass.

No-Issue: enables a clean full re-run after the extraction fixes (same session)