### PR TITLE
fix(cleanup): replace banned git branch -D with ADR-0217 graft recipe (Closes #220)

### DIFF
--- a/.claude/commands/cleanup.md
+++ b/.claude/commands/cleanup.md
@@ -119,6 +119,7 @@ Run these commands simultaneously in a single message with multiple Bash tool ca
 
    **Safety Criteria (ALL must be met to auto-delete):**
    - Branch is not `main`
+   - **Branch name does NOT match `graveyard/*`** (parked orphans, never auto-delete)
    - Remote tracking shows `gone` (was deleted on GitHub)
    - No worktree exists for this branch
 
@@ -127,7 +128,7 @@ Run these commands simultaneously in a single message with multiple Bash tool ca
    **Action based on `--no-auto-delete` flag:**
 
    a. If remote shows `gone` AND no worktree AND `--no-auto-delete` NOT set:
-      - Auto-delete: `git -C /c/Users/mcwiz/Projects/Clio branch -D {branch-name}`
+      - Delete via the **ADR-0217 graft recipe** — never `git branch -D` (banned). Graft the orphan tip onto its squash commit on `main`, then `git -C /c/Users/mcwiz/Projects/Clio branch -d {branch-name}`, then remove the graft. If the squash commit can't be identified, namespace the branch into `graveyard/<date>/{branch-name}` instead (ADR-0217 Option G').
       - Report: "AUTO-DELETE: Removed orphan branch {name} (remote gone)"
 
    b. If remote shows `gone` AND no worktree AND `--no-auto-delete` IS set:


### PR DESCRIPTION
The rendered `/cleanup` command instructed the agent to auto-delete orphan branches with the banned force-delete flag. This copy was rendered from an older AssemblyZero command template; the template was corrected on 2026-06-22, but already-rendered per-repo copies kept the banned form.

## What changed

- Replaced the force-delete instruction with the ADR-0217 graft recipe plus `git branch -d`, matching the current template wording.
- Added the `graveyard/*` skip to the auto-delete safety criteria. The graft fallback parks unresolvable orphans under `graveyard/<date>/`; without the skip, a later cleanup run would see the parked branch (remote gone, no worktree) and try to delete it again, re-nesting the namespace.

## Verification

`grep -c "branch -D"` on the file returns 1, and that single occurrence is the prohibition text naming the flag as banned — a guard, not an instruction.

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)