### PR TITLE
hygiene: untrack machine-local Claude settings (Closes #222)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "WebFetch(domain:gemini.google.com)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ docs/session-logs/
 # saved HTML pages for debugging, etc.). NEVER tracked. Always-on
 # broad rule supersedes the narrow per-file rules below.
 data/
+
+# Machine-local Claude Code config -- never track
+.claude/settings.local.json
+.claude/*.json.bak


### PR DESCRIPTION
Untracks .claude/settings.local.json (and any .bak sibling) -- machine-personal config; files stay on local disks; gitignore line prevents re-tracking. Recovery note for clones is in the issue.

Closes #222
