### PR TITLE
fix(config): repoint agent config off the removed AgentOS directory (Closes #239)

### DIFF
--- a/.claude/commands/cleanup.md
+++ b/.claude/commands/cleanup.md
@@ -104,7 +104,7 @@ Run these commands simultaneously in a single message with multiple Bash tool ca
 **Full mode adds (10 parallel calls total):**
 - git -C /c/Users/mcwiz/Projects/Clio branch -vv
 - git -C /c/Users/mcwiz/Projects/Clio branch -r
-- poetry run --directory /c/Users/mcwiz/Projects/AgentOS python /c/Users/mcwiz/Projects/AgentOS/tools/agentos-permissions.py --quick-check --project Clio
+- poetry run --directory /c/Users/mcwiz/Projects/AssemblyZero python /c/Users/mcwiz/Projects/AssemblyZero/tools/agentos-permissions.py --quick-check --project Clio
 
 ## Phase 2: Conditional Fixes
 

--- a/.claude/project.json
+++ b/.claude/project.json
@@ -6,5 +6,5 @@
     "TOOLS_DIR": "/c/Users/mcwiz/Projects/Clio/tools",
     "WORKTREE_PATTERN": "Clio-{ID}"
   },
-  "inherit_from": "C:\\Users\\mcwiz\\Projects\\AgentOS"
+  "inherit_from": "C:\\Users\\mcwiz\\Projects\\AssemblyZero"
 }

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -3,7 +3,7 @@
 ## FIRST: Read Core Rules
 
 **Before doing any work, read the AgentOS core rules:**
-`C:\Users\mcwiz\Projects\AgentOS\CLAUDE.md`
+`C:\Users\mcwiz\Projects\AssemblyZero\CLAUDE.md`
 
 That file contains core rules that apply to ALL projects and ALL agents:
 - Bash command rules (no &&, |, ;)


### PR DESCRIPTION
## Agent config in this repo points at a directory that no longer exists

One or more files here contain an absolute path to `C:\Users\mcwiz\Projects\AgentOS`. That directory was renamed and no longer exists on disk.

GitHub redirects the old `owner/name` indefinitely, so remotes and `gh` calls kept working after the rename and nothing surfaced the local breakage. Absolute filesystem paths get no such redirect.

## Why it matters

Agent configuration fails **quietly**. A dead `inherit_from` or `TOOLS_DIR` does not raise an error — the setting is simply never resolved, while the file still reads as if it were configured. In the worst instance of this same rename, a `PreToolUse` hook pointed at a deleted script and failed **open** for months while the config still read as protected.

`GEMINI.md` and `.claude/` files are loaded as instructions. A path in them that resolves to nothing is an instruction that silently does nothing.

## Fix

Substitute the path only where it appears as a project path:

```
Projects/AgentOS   ->  Projects/AssemblyZero
Projects\AgentOS   ->  Projects\AssemblyZero
```

Scoped deliberately to the path form. Occurrences of the old name in prose — history, changelogs, incident notes — are records rather than references and are left alone.

## Verification

Re-read from disk after the edit and confirm zero remaining `Projects/AgentOS` references, and that nothing else in the file moved. A fleet-wide detector reports this class and can confirm the repo is clean afterwards.

Found by a fleet scan across 105 checkouts, which found 26 files in this class. Tracked centrally in a private coordination repo.

Closes #239
